### PR TITLE
Get search working again

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: awips-docs
 channels:
   - conda-forge
 dependencies:
-  - python=2.7
+  - python=3.8
   - pip
   - pip:
     - mkdocs==0.17.5

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,9 @@ site_name: Unidata AWIPS User Manual
 site_url: http://unidata.github.io/awips2
 site_description: Documentation for all things AWIPS.
 site_author: support-awips@unidata.ucar.edu
-theme: unidata
+theme:
+  name: unidata
+  search_index_only: true
 repo_url: https://github.com/Unidata/awips2
 edit_uri: edit/unidata_18.1.1/docs/
 site_favicon: images/favicon.ico


### PR DESCRIPTION
The Unidata theme javascript isn't compatible with the version of mkdocs being used. Starting with mkdocs 0.17, the generated search index json file located at site/search/search_index.json. However, the themes application javascript file looks for mkdocs/search_index.json. Because we cannot update the theme at this point, this PR simply overrides the javascript file shipped with the theme and adds a config option that allows search to work again.