### PR TITLE
In order to add back in the cave/com.raytheon.uf.viz.gisdatastore fea…

### DIFF
--- a/cave/build/features.txt
+++ b/cave/build/features.txt
@@ -45,3 +45,4 @@ gov.noaa.gsd.viz.ensemble.feature
 edu.wisc.ssec.cimss.viz.convectprob.feature
 gov.noaa.nws.mdl.viz.boundaryTool.common.feature
 com.raytheon.uf.viz.satellite.goesr.feature
+com.raytheon.uf.viz.gisdatastore.feature

--- a/cave/build/p2-build.xml
+++ b/cave/build/p2-build.xml
@@ -280,10 +280,11 @@
 		<antcall target="p2.build.repo">
 			<param name="feature" value="gov.noaa.nws.mdl.viz.boundaryTool.common.feature" />
 		</antcall>
-	<!--
+<!--Tiff added -->
 		<antcall target="p2.build.repo">
 			<param name="feature" value="com.raytheon.uf.viz.gisdatastore.feature" />
 		</antcall>
+	<!--
 		<antcall target="p2.build.repo">
 			<param name="feature" value="gov.noaa.nws.obs.viz.geodata.feature" />
 		</antcall>

--- a/cave/com.raytheon.viz.product.awips/awips.product
+++ b/cave/com.raytheon.viz.product.awips/awips.product
@@ -120,6 +120,7 @@
       <feature id="edu.wisc.ssec.cimss.viz.convectprob.feature"/>
       <feature id="gov.noaa.nws.mdl.viz.boundaryTool.common.feature"/>
       <feature id="com.raytheon.uf.viz.satellite.goesr.feature"/>
+      <feature id="com.raytheon.uf.viz.gisdatastore.feature"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
…ture for the RPM build, the feature had to be added to the following files:

- cave/build/features.txt
- cave/build/p2-build.xml
- cave/com.raytheon.viz.product.awips/awips.product

Since it already existed in cave/com.raytheon.viz.product.awips/developer.product, it was showing up when deploying from eclipse.