### PR TITLE
Updates to website for info on remotely connecting to cave:

### DIFF
--- a/docs/install/common-problems.md
+++ b/docs/install/common-problems.md
@@ -23,6 +23,17 @@ For Mac users, the easiest way is to open a new terminal and run the following c
     rm -rf ~/Library/caveData
 
 
+---
+
+## Remotely Connecting to CAVE
+
+Since the pandemic began, many users have asked if they can use X11 forwarding or ssh tunneling to remotely connect to CAVE machines.  **This is not recommended or supported**, and CAVE crashes in many different ways and expresses strange behavior as well.
+
+We highly recommend you [download the appropriate CAVE installer](install-cave.md) on your local machine, if that is an option.
+
+If that is not an option, then the only remote access we recommend is using some type of VNC.
+[**RealVNC**](https://www.realvnc.com/en/) and [**nomachine**](https://www.nomachine.com) are two options that are in use with positive outcomes.  [**UltraVNC**](https://www.uvnc.com) may be another option, but may have quite a delay.  There *may* also be other free or paid software available that we are not aware of.
+!!! warning "It is likely that any VNC option you choose will also require some software or configuration to be set on the remote machine, and this will likely require administrative privileges."
 
 ---
 

--- a/docs/install/install-cave.md
+++ b/docs/install/install-cave.md
@@ -8,6 +8,10 @@ CAVE is the **C**ommon **A**WIPS **V**isualization **E**nvironment that is used 
 
 Regardless of what Operating System CAVE is running on, these general requirements are recommended in order for CAVE to perform optimally:
 
+- Local machine
+
+    !!! error "Running CAVE via X11 forwarding or ssh tunneling is **not** supported. Using a [VNC is the only remote option](common-problems.md#remotely-connecting-to-cave), and may result in worse performance than running locally."
+  
 - Java 1.8
 - OpenGL 2.0 Compatible Devices
 - At least 4GB RAM

--- a/docs/install/install-cave.md
+++ b/docs/install/install-cave.md
@@ -10,7 +10,7 @@ Regardless of what Operating System CAVE is running on, these general requiremen
 
 - Local machine
 
-    !!! error "Running CAVE via X11 forwarding or ssh tunneling is **not** supported. Using a [VNC is the only remote option](common-problems.md#remotely-connecting-to-cave), and may result in worse performance than running locally."
+    !!! error "Running CAVE via X11 forwarding or ssh tunneling is **not** supported. Using a [VNC connection is the only remote option](common-problems.md#remotely-connecting-to-cave), and may result in worse performance than running locally."
   
 - Java 1.8
 - OpenGL 2.0 Compatible Devices


### PR DESCRIPTION
install-cave.md:
  - add a requirement to the top of the General Requirements section stating "local machine"
  - add a note after that saying ssh tunneling and x11 forwarding are not supported, with a link to our new section in the Common Problems page about remote access options

common-problems.md:
  - add a new subsection called "Remotely Connecting to CAVE"
  - say that x11 fowarding and ssh tunneling are not supported and we highly recommend running CAVE locally
  - add some comments about nomachine and realVNC as well as ultraVNC
  - add a note saying these software packages will most likely require configuration or installation on the remote machine to be done by an administrator