### PR TITLE
Small webpage update:

### DIFF
--- a/docs/install/common-problems.md
+++ b/docs/install/common-problems.md
@@ -41,8 +41,8 @@ If that is not an option, then the only remote access we recommend is using some
 
 One common error some users are seeing manifests itself just after selecting an EDEX server to connect to.  The following error dialogs may show up:
 
-![](../images/errorPurgingLogs.png)
-![](../images/errorWorkbenchNull.png)
+![Error purging logs. Reason: Error occurred during purge and rotate](../images/errorPurgingLogs.png)
+![Error instantiating workbench: null](../images/errorWorkbenchNull.png)
 
 These errors are actually happening because the Windows machine is using IPv6, which is not compatible with AWIPS at this time.
 


### PR DESCRIPTION
- updated the common problems page to have descriptive alt descriptions for the images about the windows ipv6 startup error, this should hopefully lead to more google hits when searching for the description