### PR TITLE
Changings to WWA resources to show warings and watches properly

### DIFF
--- a/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WWAResourceData.java
+++ b/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WWAResourceData.java
@@ -75,25 +75,7 @@ public class WWAResourceData extends AbstractRequestableResourceData {
     protected AbstractVizResource<?, ?> constructResource(
             LoadProperties loadProperties, PluginDataObject[] objects)
             throws VizException {
-        boolean watchResource = false;
-        records = new ArrayList<AbstractWarningRecord>(objects.length);
-        if (objects.length > 0) {
-            for (int i = 0; i < objects.length; i++) {
-                records.add((AbstractWarningRecord) objects[i]);
-            }
-            watchResource = "A".equals(((AbstractWarningRecord) objects[0])
-                    .getSig());
-        } else if (loadProperties.isLoadWithoutData()) {
-            // I must be trying to load without data, Ill try.
-            RequestConstraint phenSig = metadataMap.get("phensig");
-            watchResource = phenSig != null
-                    && phenSig.getConstraintValue().contains(".A");
-        }
-
-        if (watchResource) {
-            return new WatchesResource(this, loadProperties);
-        }
-
+    	
         return new WarningsResource(this, loadProperties);
     }
 

--- a/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WWAResourceData.java
+++ b/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WWAResourceData.java
@@ -43,7 +43,8 @@ import com.raytheon.viz.core.mode.CAVEMode;
  * Oct 25, 2013 2249       rferrel     getAvailableTimes always returns a non-empty list.
  * Apr 28, 2014 DR 17310   D. Friedman Handle null VTEC fields.
  * Aug 28, 2014 ASM #15682 D. Friedman Refactor for WouWcnWatchesResourceData.
- * 
+ * Oct 21, 2021            srcarter    Simplified the construct method to always return WarningsResource 
+ *
  * </pre>
  * 
  * @author jsanchez

--- a/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WarningsResource.java
+++ b/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WarningsResource.java
@@ -16,6 +16,12 @@
  *
  * See the AWIPS II Master Rights File ("Master Rights File.pdf") for
  * further licensing information.
+ *
+ * SOFTWARE HISTORY
+ *
+ * Date          Ticket #    Engineer    Description
+ * ------------- ----------- ----------- -----------------------------
+ * Oct 21, 2021              srcarter    modified initShape to set the shape on watches, and wireframe on warnings and advisories
  **/
 
 package com.raytheon.viz.warnings.rsc;

--- a/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WarningsResource.java
+++ b/cave/com.raytheon.viz.warnings/src/com/raytheon/viz/warnings/rsc/WarningsResource.java
@@ -46,7 +46,6 @@ import com.raytheon.uf.viz.core.exception.VizException;
 import com.raytheon.uf.viz.core.rsc.LoadProperties;
 import com.raytheon.uf.viz.core.rsc.capabilities.ColorableCapability;
 import com.raytheon.uf.viz.core.time.TimeMatchingJob;
-import com.raytheon.viz.warnings.rsc.AbstractWWAResource.WarningEntry;
 import com.vividsolutions.jts.geom.Geometry;
 
 /**


### PR DESCRIPTION
WWAResourceData
- Simplified the constructResource to always create and return a WarningsResource
- the actual implementation of the constructResource method doesn't quite align with how it originally seemed to be designed. None of the data is actually in the PluginDataObject at this point, all the data is in the LoadProperties.  Because of that, differentiating between WatchResources and WarningResources doesn't work the way you would think it does.  You end up going through this method once, for the entire load of the WWAs.  Also, for some reason the way the WatchResource populated and eventually passed on its records for drawing, actually eliminated the watches.  So, by using the WarningsResource class all the time, all the watches, warnings, and advisories are persisted.

WarningsResource
- the proper convention is for watches to show up as a shaded (thatched) area, and the warnings and advisories to show up with an outline
- in the initShape method, look to see what the significance of the record is, and if it's a watch, then create and set the shadedShape (logic taken from the WatchesResource), otherwise create and set the wireframeShape