### PR TITLE
Unidata 18.2.1

### DIFF
--- a/cave/com.raytheon.uf.viz.d2d.ui/plugin.xml
+++ b/cave/com.raytheon.uf.viz.d2d.ui/plugin.xml
@@ -118,7 +118,7 @@
              </command>
 			 <command
                    commandId="com.raytheon.viz.ui.deleteAWIPSBundle"
-                   label="Manage Display"
+                   label="Delete Displays"
                    style="push">
              </command>
              <separator
@@ -1554,7 +1554,7 @@
             id="com.raytheon.viz.ui.deleteAWIPSBundle"
             categoryId="com.raytheon.uf.viz.d2d.ui"
             description="Delete a display (bundle)"
-            name="Manage Display">
+            name="Delete Displays">
       </command>
       <command
             id="com.raytheon.viz.ui.deleteAWIPSProcedure"

--- a/cave/com.raytheon.uf.viz.d2d.ui/plugin.xml
+++ b/cave/com.raytheon.uf.viz.d2d.ui/plugin.xml
@@ -118,7 +118,7 @@
              </command>
 			 <command
                    commandId="com.raytheon.viz.ui.deleteAWIPSBundle"
-                   label="Manage Bundles"
+                   label="Manage Display"
                    style="push">
              </command>
              <separator
@@ -1553,8 +1553,8 @@
       <command
             id="com.raytheon.viz.ui.deleteAWIPSBundle"
             categoryId="com.raytheon.uf.viz.d2d.ui"
-            description="Delete a bundle"
-            name="Manage Bundles">
+            description="Delete a display (bundle)"
+            name="Manage Display">
       </command>
       <command
             id="com.raytheon.viz.ui.deleteAWIPSProcedure"

--- a/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/actions/DeleteAWIPSBundle.java
+++ b/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/actions/DeleteAWIPSBundle.java
@@ -61,7 +61,7 @@ public class DeleteAWIPSBundle extends AbstractHandler {
     public Object execute(ExecutionEvent event) throws ExecutionException {
         if (listDlg == null || listDlg.getShell() == null
                 || listDlg.isDisposed()) {
-            listDlg = new VizLocalizationFileListDlg("Delete Bundle",
+            listDlg = new VizLocalizationFileListDlg("Delete Display",
                     HandlerUtil.getActiveShell(event), Mode.DELETE,
                     SavePerspectiveHandler.PERSPECTIVES_DIR, "perspectives",
                     LocalizationType.COMMON_STATIC);

--- a/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/dialogs/procedures/AlterBundleDlg.java
+++ b/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/dialogs/procedures/AlterBundleDlg.java
@@ -113,7 +113,7 @@ public class AlterBundleDlg extends CaveSWTDialog {
 
     protected AlterBundleDlg(Bundle bundle, Shell parentShell) {
         super(parentShell, SWT.DIALOG_TRIM, CAVE.DO_NOT_BLOCK);
-        setText("Alter Bundle on Loading");
+        setText("Alter Procedure Item on Loading");
 
         this.bundle = bundle;
         this.contribListenerMap = new HashMap<IAlterBundleContributor, IAlterBundleChangeListener>();

--- a/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/dialogs/procedures/HistoryListDlg.java
+++ b/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/dialogs/procedures/HistoryListDlg.java
@@ -266,7 +266,7 @@ public class HistoryListDlg extends CaveSWTDialog {
         gd = new GridData(SWT.FILL, SWT.DEFAULT, true, false);
         gd.horizontalSpan = 2;
         Button alterBundleBtn = new Button(buttonComp, SWT.PUSH);
-        alterBundleBtn.setText("Alter Bundle...");
+        alterBundleBtn.setText("Alter Procedure Item...");
         alterBundleBtn.setLayoutData(gd);
         alterBundleBtn.setEnabled(true);
         alterBundleBtn.addSelectionListener(new SelectionAdapter() {

--- a/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/dialogs/procedures/ProcedureDlg.java
+++ b/cave/com.raytheon.uf.viz.d2d.ui/src/com/raytheon/uf/viz/d2d/ui/dialogs/procedures/ProcedureDlg.java
@@ -578,8 +578,8 @@ public class ProcedureDlg extends CaveSWTDialog implements IWorkbenchListener {
                 BundlePair b = bundles.get(idx);
                 boolean done = false;
                 while (!done) {
-                    InputDialog id = new InputDialog(shell, "Enter Bundle Name",
-                            "Enter bundle name:", b.name, null);
+                    InputDialog id = new InputDialog(shell, "Enter Procedure Item Name",
+                            "Enter Item name:", b.name, null);
                     if (Window.OK == id.open()) {
                         String newName = id.getValue();
 


### PR DESCRIPTION
- Changed "Delete Bundle" to "Delete Display"
- Changed "Alter Bundle on Loading" to "Alter Procedure Item on Loading"
- Changed History List dialog from "Alter Bundle" to "Alter Procedure Item" (not sure if this one is actually used in CAVE currently)
- Changed "Enter Bundle Name" to "Enter Procedure Item Name"
- Changed "Manage Bundles" to "Delete Displays"