### PR TITLE
Unidata 18.2.1 windows

### DIFF
--- a/build/buildEnvironment.sh
+++ b/build/buildEnvironment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Version
 export AWIPSII_VERSION="18.2.1"
-export AWIPSII_RELEASE="2"
+export AWIPSII_RELEASE="3"
 # Author
 export AWIPSII_BUILD_VENDOR="UCAR"
 export AWIPSII_BUILD_SITE="Unidata"

--- a/cave/com.raytheon.viz.product.awips/developer.product
+++ b/cave/com.raytheon.viz.product.awips/developer.product
@@ -37,7 +37,7 @@
 -XX:G1MixedGCLiveThresholdPercent=25
 -XX:G1OldCSetRegionThresholdPercent=25
 -XX:G1HeapWastePercent=5
--DcaveVersion=18.2.1-1
+-DcaveVersion=18.2.1-3
 -DbuildSystem=RHEL/Eclipse
 -XX:SoftRefLRUPolicyMSPerMB=1000
       </vmArgs>
@@ -59,11 +59,9 @@
       </win>
    </launcher>
 
-
    <vm>
       <windows include="true">jdk1.7.0</windows>
    </vm>
-
 
    <plugins>
    </plugins>

--- a/cave/com.raytheon.viz.warngen/src/com/raytheon/viz/warngen/gui/WarngenDialog.java
+++ b/cave/com.raytheon.viz.warngen/src/com/raytheon/viz/warngen/gui/WarngenDialog.java
@@ -431,8 +431,10 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
 
         GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
         mainComposite.setLayoutData(gd);
-        tabs.setLayoutData(gd);
-
+        if(tabs !=null){
+        	tabs.setLayoutData(gd);
+        }
+        
         createBackupTrackEditGroups(mainComposite);
         createRedrawBoxGroup(mainComposite);
         createProductTypeGroup(mainComposite);
@@ -517,13 +519,13 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
         gl.verticalSpacing = 2;
         gl.marginHeight = 1;
         timeRange.setLayout(gl);
-        timeRange.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1,
+        timeRange.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1,
                 1));
         
         Composite timeRangeComp = new Composite(timeRange, SWT.NONE);
         timeRangeComp.setLayout(new GridLayout(3, false));
         timeRangeComp.setLayoutData(new GridData(SWT.DEFAULT, SWT.FILL, false,
-                true));
+                false));
         
         GridData gd = new GridData();
         gd.horizontalSpan = 1;
@@ -776,7 +778,7 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
 
         restartBtn = new Button(backupTrackEditComp, SWT.PUSH);
         restartBtn.setText("Reset");
-        GridData gd = new GridData(SWT.CENTER, SWT.CENTER, true, true);
+        GridData gd = new GridData(SWT.CENTER, SWT.CENTER, true, false);
         gd.widthHint = 100;
         restartBtn.setLayoutData(gd);
         restartBtn.addSelectionListener(new SelectionAdapter() {
@@ -788,7 +790,7 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
         createTrackGroup(backupTrackEditComp);
         createEditGroup(backupTrackEditComp);
         
-        gd = new GridData(SWT.FILL, SWT.FILL, true, true);
+        gd = new GridData(SWT.FILL, SWT.FILL, true, false);
         gd.heightHint = 40;
         instructionsBox = new Text(mainComposite, SWT.NONE | SWT.READ_ONLY
                 | SWT.MULTI);
@@ -805,7 +807,7 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
         gl.marginHeight = 1;
         trackGroup.setLayout(gl);
         trackGroup.setLayoutData(new GridData(SWT.DEFAULT, SWT.FILL, false,
-                true));
+                false));
         trackGroup.setBackgroundMode(SWT.INHERIT_NONE);
         
         oneStorm = new Button(trackGroup, SWT.RADIO);
@@ -849,7 +851,7 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
         gl.marginHeight = 1;
         editGroup.setLayout(gl);
         editGroup.setLayoutData(
-                new GridData(SWT.DEFAULT, SWT.FILL, false, true));
+                new GridData(SWT.DEFAULT, SWT.FILL, false, false));
 
         box = new Button(editGroup, SWT.RADIO);
         box.setText("Box");
@@ -897,7 +899,7 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
 
         okButton = new Button(buttonComp, SWT.PUSH);
         okButton.setText(OK_BTN_LABEL);
-        GridData gd = new GridData(SWT.CENTER, SWT.CENTER, true, true);
+        GridData gd = new GridData(SWT.CENTER, SWT.CENTER, true, false);
         gd.widthHint = 100;
         okButton.setLayoutData(gd);
         okButton.addSelectionListener(new SelectionAdapter() {
@@ -917,7 +919,7 @@ IWarningsArrivedListener, ISimulatedTimeChangeListener {
 
         Button btn = new Button(buttonComp, SWT.PUSH);
         btn.setText(CLOSE_BUTTON_LABEL);
-        gd = new GridData(SWT.CENTER, SWT.CENTER, true, true);
+        gd = new GridData(SWT.CENTER, SWT.CENTER, true, false);
         gd.widthHint = 100;
         btn.setLayoutData(gd);
         btn.addSelectionListener(new SelectionAdapter() {

--- a/cave/com.raytheon.viz.warngen/src/com/raytheon/viz/warngen/gui/WarngenDialog.java
+++ b/cave/com.raytheon.viz.warngen/src/com/raytheon/viz/warngen/gui/WarngenDialog.java
@@ -208,6 +208,8 @@ import com.vividsolutions.jts.geom.Polygon;
  *  Nov 17, 2021           srcarter@ucar Set reasonable height, allow proper resizing, remove instructions label call because 
  *                                       it's null and never used, change bulletlist functionality so it doesn't scroll to the
  *                                       top as soon as a user makes a selection
+ *  Dec 20, 2021           srcarter@ucar Check for null before setting layout data on tabs. Make all other components have false
+ *                                       for vertical expansion so the resizing only resizes the bullet list                                     
  * </pre>
  *
  * @author chammack

--- a/rpms/awips2.edex/Installer.edex/component.spec
+++ b/rpms/awips2.edex/Installer.edex/component.spec
@@ -61,6 +61,20 @@ mkdir -p %{_build_root}/awips2/edex/data/share
 if [ $? -ne 0 ]; then
    exit 1
 fi
+mkdir -p %{_build_root}/awips2/edex/data/ndm
+if [ $? -ne 0 ]; then
+   exit 1
+fi
+
+mkdir -p %{_build_root}/awips2/dev
+if [ $? -ne 0 ]; then
+   exit 1
+fi
+
+mkdir -p %{_build_root}/awips2/dev/logs
+if [ $? -ne 0 ]; then
+   exit 1
+fi
 
 /bin/cp -r %{_baseline_workspace}/rpms/awips2.edex/Installer.edex/programs/qpidNotify.py ${RPM_BUILD_ROOT}/awips2/edex/bin/
 
@@ -194,6 +208,8 @@ rm -rf ${RPM_BUILD_ROOT}
 %dir /awips2/edex/bin
 /awips2/edex/bin/*.sh
 /awips2/edex/bin/scriptLauncher
+#%dir /awips2/dev/logs
 %attr(755,awips,fxalpha) /awips2/edex/bin/qpidNotify.py
 %attr(755,awips,fxalpha) /awips2/dev/updateNDM.pl
+%attr(755,awips,fxalpha) /awips2/dev/logs/updateNDM.log
 %attr(744,root,root) /etc/init.d/edex_camel


### PR DESCRIPTION
Bring over recent changes to main unidata_18.2.1 repo:

- small changes to the WarngenDialog to prevent exception on the mac, and to have proper resizing behavior
- small change to installer for NDM files
- update the version to 18.2.1-3 (think this only affects linux because mac and windows have different build processes though)