### PR TITLE
Added wording stating CentOS7 End of Life isn't until June 30, 2024 (…

### DIFF
--- a/docs/install/install-cave.md
+++ b/docs/install/install-cave.md
@@ -41,6 +41,8 @@ Regardless of what Operating System CAVE is running on, these general requiremen
 
 - 64 bit CentOS/Red Hat 7
 
+!!! note "While CentOS8 has reach End of Life as of Dec. 31, 2021, CentOS7 End of Life isn't until June 30, 2024."
+
 ### Download and Installation Instructions
 
 1. Download the following installer: [**awips_install.sh** <i class="fa fa-download"></i>](https://downloads.unidata.ucar.edu/awips2/current/linux/awips_install.sh)

--- a/docs/install/install-edex.md
+++ b/docs/install/install-edex.md
@@ -16,6 +16,9 @@ EDEX is the **E**nvironmental **D**ata **Ex**change system that represents the b
 ## System requirements
 
 - 64-bit CentOS/RHEL 7
+
+!!! note "While CentOS8 has reach End of Life as of Dec. 31, 2021, CentOS7 End of Life isn't until June 30, 2024."  
+
 - 16+ CPU cores (each CPU core can run a decorder in parallel)
 - 24GB RAM
 - 700GB+ Disk Space


### PR DESCRIPTION
…even though CentOS8 has reached End of Life on Dec 31, 2021)