### PR TITLE
Small fix to documentation

### DIFF
--- a/docs/install/install-edex.md
+++ b/docs/install/install-edex.md
@@ -1,6 +1,6 @@
 # Install EDEX <i class="fa fa-linux"></i>
 
-EDEX is the **E**nvironmental **D**ata **Ex**change system that represents the backend server for AWIPS.  EDEX is only supported for Linux systems: CentOS and RHEL, and ideally, it should be on its own dedicated machine.  It requires administrator priviledges to make root-level changes. EDEX can run on a single machine or be spread across multiple machines.  To learn more about that please look at [Distributed EDEX, Installing Across Multiple Machines](/edex/distributed-computing/)
+EDEX is the **E**nvironmental **D**ata **Ex**change system that represents the backend server for AWIPS.  EDEX is only supported for Linux systems: CentOS and RHEL, and ideally, it should be on its own dedicated machine.  It requires administrator priviledges to make root-level changes. EDEX can run on a single machine or be spread across multiple machines.  To learn more about that please look at [Distributed EDEX, Installing Across Multiple Machines](../../edex/distributed-computing/)
 
 ---
 


### PR DESCRIPTION
- had a broken link on the edex install page, that just needed a slightly different relative path to get to the proper page