### PR TITLE
Updated radarsInUse.txt files for WFO's that were outdated

### DIFF
--- a/localization/utility/common_static/site/BOU/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/BOU/radar/radarsInUse.txt
@@ -1,6 +1,7 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 kftg
+tden
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/BTV/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/BTV/radar/radarsInUse.txt
@@ -1,6 +1,7 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 kcxx
+ktyx
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/BUF/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/BUF/radar/radarsInUse.txt
@@ -1,7 +1,6 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 kbuf
-ktvx
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/FGZ/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/FGZ/radar/radarsInUse.txt
@@ -1,6 +1,6 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
-ksfx
+kfsx
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/FWD/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/FWD/radar/radarsInUse.txt
@@ -1,6 +1,7 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 kfws
+kgrk
 tdal
 tdfw
 

--- a/localization/utility/common_static/site/ICT/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/ICT/radar/radarsInUse.txt
@@ -1,6 +1,7 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 kict
+tich
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/LIX/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/LIX/radar/radarsInUse.txt
@@ -1,7 +1,6 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 klix
-kbix
 tmsy
 
 # DIAL_RADARS - MUST HAVE THIS LINE

--- a/localization/utility/common_static/site/LOT/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/LOT/radar/radarsInUse.txt
@@ -2,6 +2,7 @@
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 klot
 tmdw
+tord
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/LSX/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/LSX/radar/radarsInUse.txt
@@ -1,6 +1,7 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 klsx
+tstl
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/LWX/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/LWX/radar/radarsInUse.txt
@@ -2,7 +2,9 @@
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 klwx
 tiad
-
+tadw
+tbwi
+tdca
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/OAX/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/OAX/radar/radarsInUse.txt
@@ -3,7 +3,6 @@
 koax
 tmsp
 ktlx
-tjua
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/OKX/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/OKX/radar/radarsInUse.txt
@@ -2,7 +2,7 @@
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
 kokx
 tewr
-tjkf
+tjfk
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/OUN/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/OUN/radar/radarsInUse.txt
@@ -4,7 +4,6 @@ ktlx
 kvnx
 kfdr
 tokc
-tpsf
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 

--- a/localization/utility/common_static/site/PSR/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/PSR/radar/radarsInUse.txt
@@ -1,6 +1,6 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
-kyuk
+kyux
 kiwa
 tphx
 

--- a/localization/utility/common_static/site/TFX/radar/radarsInUse.txt
+++ b/localization/utility/common_static/site/TFX/radar/radarsInUse.txt
@@ -1,6 +1,6 @@
 # DO NOT EDIT LINES BEGINNING WITH '#'
 # LOCAL_RADARS (including terminal) - MUST HAVE THIS LINE
-kftx
+ktfx
 
 # DIAL_RADARS - MUST HAVE THIS LINE
 


### PR DESCRIPTION
(in localization/common_static/site)

-Removed KBIX from LIX (AFB where we don't get the radar data) -Removed KSFX from FGZ (incorrect radar for the CWA) -Added KFSX to FGZ (added correct radar for the CWA) -Renamed KFTX to KTFX for TFX (corrected radar name) -Added KGRK to FWD (update)
-Removed KTVX from BUF (no idea where this came from) -Added KTYX to BTV (update)
-Renamed KYUK to KYUX for BTV (corrected radar name) -Added TADW to LWX (update)
-Added TBWI to LWX (update)
-Added TDCA to LWX (update)
-Added TDEN to BOU (update)
-Added TICH to ITC (update)
-Renamed TJKF to TJFK for OKX (corrected radar name) -Removed TJUA from OAX (just need it in SJU)
-Added TORD to LOT (update)
-Removed TPSF from OUN (don't get radar data)
-Added TSTL to LSX (update)