### PR TITLE
Small documentation changes to point people to the mac beta installer

### DIFF
--- a/docs/appendix/common-problems.md
+++ b/docs/appendix/common-problems.md
@@ -63,7 +63,9 @@ If you are running MacOS Monterey, you may see the following message when starti
 
 ![Monterey warning](../images/monterey-warning.png)
 
-This message can be ignored, and will hopefully go away when we release version 20+ of AWIPS.
+Monterey versions 12.3 or newer will not support our production (v18) CAVE.
+
+Please [download and install our beta v20 CAVE](../install/install-cave-beta-v20.md#macos) for newer MacOS Versions.
 
 ---
 

--- a/docs/install/install-cave.md
+++ b/docs/install/install-cave.md
@@ -180,7 +180,7 @@ To run CAVE, either:
 
 ### System Requirements
 
-!!! error "MacOS Monterey version 12.3 and above no longer supports Python2.  This will cause several visualization aspects to fail in CAVE.  If you update to MacOS 12.3 CAVE will not be fully functional.  A potential workaround is to run a Virtual Machine with a different OS (older Mac or possibly CentOS7) and run CAVE inside of that."
+!!! error "MacOS Monterey version 12.3 and above no longer supports Python2.  This will cause several visualization aspects to fail in CAVE.  If you update to MacOS 12.3 CAVE will not be fully functional.  Please [download and install our beta v20 of CAVE](install-cave-beta-v20.md#macos) for newer MacOS versions."
 
 - Will need admin privileges to install `awips-python.pkg`
 - NVIDIA Graphics card is recommended, however some Intel Graphics cards will support a majority of the functionality


### PR DESCRIPTION
Added to the Common Problems page (problem with Monterey) 
Updated the specific mac installer section on the cave install page