### PR TITLE
Modified menu files to properly open four panel displays in new editors

### DIFF
--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarComp05VILMax.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarComp05VILMax.xml
@@ -1,592 +1,1138 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-<!-- Load Composite Reflectivity Mosaic Best res, 0.5 Refl, Vil, LayerMax Refl, in 4 panels
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
-                    <loadProperties>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarMosaicResourceData"
-                        mosaicType="MergeRaster" mergeUpperText="true"
-                        retrieveData="false" productName="${icao} Composite Refl">
+                    <resourceData xsi:type="radarMosaicResourceData" productName="${icao} Composite Refl" mosaicType="MergeRaster" mergeUpperText="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="38,36,37,35"
-                                    constraintType="IN" />
-                            </mapping>
                             <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
+                            </mapping>
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="38,36,37,35"/>
                             </mapping>
                         </metadataMap>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="bestResResourceData"
-                                productIdentifierKey="productCode"
-                                retrieveData="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="37,35"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="37"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="35"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
+                            <resourceData xsi:type="bestResResourceData" productIdentifierKey="productCode" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="37,35"/>
+    </mapping>
+</metadataMap>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="colorMapCapability">
+                <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+                    <persisted/>
+                </colorMapParameters>
+            </capability>
+            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="37"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="35"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="bestResResourceData"
-                                productIdentifierKey="productCode"
-                                retrieveData="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="38,36"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="38"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="36"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
+                            <resourceData xsi:type="bestResResourceData" productIdentifierKey="productCode" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="38,36"/>
+    </mapping>
+</metadataMap>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="38"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="36"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
-            </descriptor>
-        </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <descriptor xsi:type="mapDescriptor">
                 <resource>
-                    <loadProperties>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="bestResResourceData"
-                        productIdentifierKey="productCode" retrieveData="false">
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
+            </descriptor>
+        </displays>
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
+            <descriptor xsi:type="mapDescriptor">
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="bestResResourceData" productIdentifierKey="productCode" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="153,94,19,20"
-                                    constraintType="IN" />
-                            </mapping>
                             <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
                             </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="153,94,19,20"/>
                             </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.5"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="0.5"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="0.5"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="153"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="0.5"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="94}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="0.5"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="94"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="0.5"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="19"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="0.5"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="19"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="0.5"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="20"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="EQUALS"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="EQUALS"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="65"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="65"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/OSF/16 Level Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="57"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="57"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarDualPolBaseData.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarDualPolBaseData.xml
@@ -1,469 +1,1065 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-<!-- loads four panel base data, looks like this
-
-     +++++++++++++++++++++++
-     + Z    SRM + ZDR    V +
-     +++++++++++++++++++++++
-     + KDP    HC + CC   SW +
-     +++++++++++++++++++++++
-     
-     substitution keys:
-         product    the productCode to load
-         elev       a range of elevations to load seperated by two dashes.
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153,94,19,20"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="153,94,19,20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/8 bit Vel">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="SRM8" isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="154,99"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="SRM8" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="154,99"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Differential Refl">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="159,158"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="159,158"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/8 bit Vel">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="154,99,27,25"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="154,99,27,25"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Spec Differential Phase">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="163,162"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="163,162"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Hydrometeor Class">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="165,164"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="165,164"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Correlation Coeff">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="161,160"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="161,160"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Correlation Coeff">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="155,28,29,30,161,160"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="155,28,29,30,161,160"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarDualPolFourPanelZHCML.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarDualPolFourPanelZHCML.xml
@@ -1,557 +1,1185 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-    <!-- loads four panel HCA analysis, looks like this 
-    +++++++++++++++++++++++ 
-    +  Z   HC  +  Z   HC  + 
-    +    ML    +    ML    + 
-    +++++++++++++++++++++++
-    +  Z   HC  +  Z   HC  + 
-    +    ML    +    ML    +
-    +++++++++++++++++++++++ 
-    substitution keys:
-       product the productCode to load
-       elev     a range of elevations to load seperated by two dashes. -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                        </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="blendedResourceData">
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="153,94,19,20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Hydrometeor Class">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="165,164"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
+                        <capabilities>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="PLOT">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation1}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${elevation1}"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="166"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="166"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
-                <resource>
-                    <loadProperties loadWithoutData="true">
-                        <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
-                        </capabilities>
-                    </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
-                    </properties>
-                    <resourceData xsi:type="blendedResourceData">
-                        <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153,94,19,20"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation1}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                        </resource>
-                        <resource>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="165,164"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                        </resource>
-                    </resourceData>
-                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                        </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="blendedResourceData">
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="153,94,19,20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Hydrometeor Class">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="165,164"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="PLOT">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation2}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${elevation2}"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="166"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="166"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
-                <resource>
-                    <loadProperties loadWithoutData="true">
-                        <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
-                        </capabilities>
-                    </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
-                    </properties>
-                    <resourceData xsi:type="blendedResourceData">
-                        <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153,94,19,20"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation2}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                        </resource>
-                        <resource>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="165,164"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                        </resource>
-                    </resourceData>
-                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                        </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="blendedResourceData">
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="153,94,19,20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation3}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Hydrometeor Class">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="165,164"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation3}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="PLOT">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation3}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${elevation3}"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="166"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="166"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
-                <resource>
-                    <loadProperties loadWithoutData="true">
-                        <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
-                        </capabilities>
-                    </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
-                    </properties>
-                    <resourceData xsi:type="blendedResourceData">
-                        <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153,94,19,20"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation3}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                        </resource>
-                        <resource>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                >
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="165,164"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation3}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                        </resource>
-                    </resourceData>
-                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                        </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="blendedResourceData">
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="153,94,19,20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation4}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Hydrometeor Class">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="165,164"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation4}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="PLOT">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation4}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${elevation4}"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="166"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="166"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
-                <resource>
-                    <loadProperties loadWithoutData="true">
-                        <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
-                        </capabilities>
-                    </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
-                    </properties>
-                    <resourceData xsi:type="blendedResourceData">
-                        <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153,94,19,20"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                        </resource>
-                        <resource>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="165,164"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation4}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                            </resourceData>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
-                            </loadProperties>
-                        </resource>
-                    </resourceData>
-                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarDualPolHCA.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarDualPolHCA.xml
@@ -1,304 +1,931 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-<!-- loads four panel HCA analysis, looks like this
-
-     +++++++++++++++++++++++
-     +    Z     +   ZDR    +
-     +++++++++++++++++++++++
-     + HC   KDP +    CC    +
-     +    ML    +          +
-     +++++++++++++++++++++++
-     
-     substitution keys:
-         product    the productCode to load
-         elev       a range of elevations to load seperated by two dashes.
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="153,94,19,20"
-                                    constraintType="IN" />
-                            </mapping>
                             <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
                             </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="153,94,19,20"/>
                             </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation}"
-                                    constraintType="BETWEEN" />
+<constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
-            </descriptor>
-        </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <descriptor xsi:type="mapDescriptor">
                 <resource>
-                    <loadProperties loadWithoutData="true">
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
-                        <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="159,158"
-                                    constraintType="IN" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation}"
-                                    constraintType="BETWEEN" />
-                            </mapping>
-                        </metadataMap>
-                    </resourceData>
-                </resource>
-            </descriptor>
-        </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <descriptor xsi:type="mapDescriptor">
-                <resource>
-                    <loadProperties loadWithoutData="true">
-                        <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
-                        </capabilities>
-                    </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
-                    </properties>
-                    <resourceData xsi:type="blendedResourceData">
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="163,162"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="165,164"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation}"
-                                            constraintType="BETWEEN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
+            </descriptor>
+        </displays>
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
+            <descriptor xsi:type="mapDescriptor">
+                <resource>
+                    <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/DualPol/Differential Refl">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+                        <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="159,158"/>
+                            </mapping>
+                            <mapping key="primaryElevationAngle">
+<constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
+                            </mapping>
+                        </metadataMap>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
+            </descriptor>
+        </displays>
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
+            <descriptor xsi:type="mapDescriptor">
+                <resource>
+                    <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="blendedResourceData">
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Spec Differential Phase">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="163,162"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/DualPol/Hydrometeor Class">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="165,164"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
                 <resource>
                     <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true" />
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="PLOT">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="166"
-                                    constraintType="EQUALS" />
-                            </mapping>
                             <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
                             </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+                            <mapping key="productCode">
+<constraint constraintType="EQUALS" constraintValue="166"/>
                             </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation}"
-                                    constraintType="BETWEEN" />
+<constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/DualPol/Correlation Coeff">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="161,160"
-                                    constraintType="IN" />
-                            </mapping>
                             <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
                             </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="161,160"/>
                             </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="${elevation}"
-                                    constraintType="BETWEEN" />
+<constraint constraintType="BETWEEN" constraintValue="${elevation}"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarFourPanelBlended.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarFourPanelBlended.xml
@@ -1,468 +1,1023 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
- <!-- loads the same two products on all four panes, each pane at a different elevation.
-         
-         substitution keys:
-                product1        the productCode to load on the left for all 4 panes
-                product2        the productCode to load on the right for all 4 panes
-                icao            the icao, kxxx or something like that
-                elev1           the elevation to load in the upper left panel
-                elev2           the elevation to load in the upper right panel
-                elev3           the elevation to load in the lower right panel
-                elev4           the elevation to load in the lower left panel
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation1}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/OSF/SRM Radial Velocity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation1}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation2}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation2}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation4}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevationa}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation4}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevationa}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation3}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation3}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="blendedCapability"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation3}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product2}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="${elevation3}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="${product2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarFourPanelBlendedBestRes.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarFourPanelBlendedBestRes.xml
@@ -1,485 +1,1065 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-<!-- blends two sets of up to 4 radar products displaying only the best res 
-     ones on each side in four panels, each panel is a different elevation
-     
-     substitution keys:
-         product1    the productCode of the highest resolution data on the left
-         product2    the productCode of the next highest resolution data on the left
-         product3    the productCode of the next highest resolution data on the left, or empty string for none
-         product4    the productCode of the lowest resolution data on the left, or empty string for none
-         product5    the productCode of the highest resolution data on the right
-         product6    the productCode of the next highest resolution data on the right
-         product7    the productCode of the next highest resolution data on the right, or empty string for none
-         product8    the productCode of the lowest resolution data on the right, or empty string for none
-         mode1       the special mode for the resource on the left, most of the time an empty string
-         mode2       the special mode for the resource on the right, most of the time an empty string
-         icao        the icao, kxxx or something like that
-         elev2       the elevation to load in the upper left panel
-         elev3       the elevation to load in the upper right panel
-         elev4       the elevation to load in the lower right panel
-         elev4       the elevation to load in the lower left panel
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode1}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1},${product2},${product3},${product4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation1}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode1}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product1},${product2},${product3},${product4}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/8 bit Vel">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode2}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product5},${product6},${product7},${product8}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation1}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode2}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product5},${product6},${product7},${product8}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation1}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode1}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1},${product2},${product3},${product4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation2}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode1}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product1},${product2},${product3},${product4}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/8 bit Vel">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode2}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product5},${product6},${product7},${product8}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation2}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode2}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product5},${product6},${product7},${product8}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation2}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode1}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1},${product2},${product3},${product4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode1}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product1},${product2},${product3},${product4}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation4}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/8 bit Vel">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode2}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product5},${product6},${product7},${product8}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode2}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product5},${product6},${product7},${product8}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation4}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="blendableCapability" resourceIndex="0" alphaStep="8"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
                     <resourceData xsi:type="blendedResourceData">
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.46666664"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode1}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product1},${product2},${product3},${product4}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation3}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode1}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product1},${product2},${product3},${product4}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation3}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties
-                                loadWithoutData="true">
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="true">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/8 bit Vel">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="0.53333336"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="blendedCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                mode="${mode2}"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="${product5},${product6},${product7},${product8}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="${elevation3}"
-                                            constraintType="IN" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="${mode2}" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="${product5},${product6},${product7},${product8}"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="IN" constraintValue="${elevation3}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarTot1hr3hrComp.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarTot1hr3hrComp.xml
@@ -1,366 +1,961 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-<!-- Load Composite Reflectivity Mosaic Best res, 0.5 Refl, Vil, LayerMax Refl, in 4 panels
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/OSF/1, 3 Hr Precip Accumulation">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="80"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="80"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/OSF/1, 3 Hr Precip Accumulation">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="78"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="78"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
-                    <loadProperties>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="bestResResourceData"
-                        productIdentifierKey="productCode" retrieveData="false">
+                    <resourceData xsi:type="bestResResourceData" productIdentifierKey="productCode" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="153,94,19,20"
-                                    constraintType="IN" />
-                            </mapping>
                             <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
                             </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="153,94,19,20"/>
                             </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.5"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="0.5"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="153"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="0.5"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="153"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="0.5"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="94}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="0.5"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="94"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="0.5"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="19"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="0.5"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="19"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="0.5"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="radarResourceData"
-                                isUpdatingOnMetadataOnly="false"
-                                isRequeryNecessaryOnTimeMatch="true"
-                                isBlended="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="20"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="primaryElevationAngle">
-                                        <constraint
-                                            constraintValue="EQUALS"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
+                            <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="EQUALS" constraintValue="20"/>
+    </mapping>
+    <mapping key="primaryElevationAngle">
+        <constraint constraintType="EQUALS" constraintValue="EQUALS"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+</metadataMap>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="79"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="79"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarVILCompMax2Max3.xml
+++ b/cave/com.raytheon.viz.radar/localization/bundles/DefaultRadarVILCompMax2Max3.xml
@@ -1,421 +1,1010 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <!--
-        This_software_was_developed_and_/_or_modified_by_Raytheon_Company,
-        pursuant_to_Contract_DG133W-05-CQ-1067_with_the_US_Government.
-        
-        U.S._EXPORT_CONTROLLED_TECHNICAL_DATA
-        This_software_product_contains_export-restricted_data_whose
-        export/transfer/disclosure_is_restricted_by_U.S._law._Dissemination
-        to_non-U.S._persons_whether_in_the_United_States_or_abroad_requires
-        an_export_license_or_other_authorization.
-        
-        Contractor_Name:________Raytheon_Company
-        Contractor_Address:_____6825_Pine_Street,_Suite_340
-        ________________________Mail_Stop_B8
-        ________________________Omaha,_NE_68106
-        ________________________402.291.0100
-        
-        See_the_AWIPS_II_Master_Rights_File_("Master_Rights_File.pdf")_for
-        further_licensing_information.
-    -->
-    <!-- 
-        This is an absolute override file, indicating that a higher priority 
-        version of the file will completely replace a lower priority version
-        of the file. 
-    -->
-<!-- Load Composite Reflectivity Mosaic Best res, 0.5 Refl, Vil, LayerMax Refl, in 4 panels
- -->
-<bundle>
+<bundle name="4 Panel Map">
     <displayList>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="true"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/OSF/16 Level Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="57"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="57"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
-            </descriptor>
-        </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <descriptor xsi:type="mapDescriptor">
                 <resource>
-                    <loadProperties>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarMosaicResourceData"
-                        mosaicType="MergeRaster" mergeUpperText="true"
-                        retrieveData="false" productName="${icao} Composite Refl">
-                        <metadataMap>
-                            <mapping key="productCode">
-                                <constraint constraintValue="38,36,37,35"
-                                    constraintType="IN" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                        </metadataMap>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="bestResResourceData"
-                                productIdentifierKey="productCode"
-                                retrieveData="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="37,35"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="37"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="35"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
                             </resourceData>
                         </resource>
                         <resource>
-                            <loadProperties>
-                                <capabilities>
-                                    <capability xsi:type="imagingCapability"
-                                        interpolationState="false"
-                                        brightness="1.0" contrast="1.0"
-                                        alpha="1.0" />
-                                    <capability
-                                        xsi:type="rangeRingsOverlayCapability" />
-                                </capabilities>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
                             </loadProperties>
-                            <properties isSystemResource="false"
-                                isBlinking="false" isMapLayer="false"
-                                isHoverOn="false" isVisible="true">
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
                             </properties>
-                            <resourceData xsi:type="bestResResourceData"
-                                productIdentifierKey="productCode"
-                                retrieveData="false">
-                                <metadataMap>
-                                    <mapping key="productCode">
-                                        <constraint
-                                            constraintValue="38,36"
-                                            constraintType="IN" />
-                                    </mapping>
-                                    <mapping key="icao">
-                                        <constraint
-                                            constraintValue="${icao}"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                    <mapping key="pluginName">
-                                        <constraint
-                                            constraintValue="radar"
-                                            constraintType="EQUALS" />
-                                    </mapping>
-                                </metadataMap>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="38"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
-                                <resource>
-                                    <loadProperties>
-                                        <capabilities>
-                                            <capability
-                                                xsi:type="imagingCapability"
-                                                interpolationState="false"
-                                                brightness="1.0"
-                                                contrast="1.0" alpha="1.0" />
-                                            <capability
-                                                xsi:type="rangeRingsOverlayCapability" />
-                                        </capabilities>
-                                    </loadProperties>
-                                    <properties
-                                        isSystemResource="false"
-                                        isBlinking="false" isMapLayer="false"
-                                        isHoverOn="false" isVisible="true">
-                                    </properties>
-                                    <resourceData xsi:type="radarResourceData"
-                                        isUpdatingOnMetadataOnly="false"
-                                        isRequeryNecessaryOnTimeMatch="true">
-                                        <metadataMap>
-                                            <mapping key="productCode">
-                                                <constraint
-                                                    constraintValue="36"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="icao">
-                                                <constraint
-                                                    constraintValue="${icao}"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                            <mapping key="pluginName">
-                                                <constraint
-                                                    constraintValue="radar"
-                                                    constraintType="EQUALS" />
-                                            </mapping>
-                                        </metadataMap>
-                                    </resourceData>
-                                </resource>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
                             </resourceData>
                         </resource>
                     </resourceData>
                 </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
+            <descriptor xsi:type="mapDescriptor">
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+                        <capabilities>
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+                            <capability xsi:type="colorMapCapability">
+<colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+    <persisted/>
+</colorMapParameters>
+                            </capability>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="radarMosaicResourceData" productName="${icao} Composite Refl" mosaicType="MergeRaster" mergeUpperText="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+                        <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
+                            <mapping key="pluginName">
+<constraint constraintType="EQUALS" constraintValue="radar"/>
+                            </mapping>
+                            <mapping key="productCode">
+<constraint constraintType="IN" constraintValue="38,36,37,35"/>
+                            </mapping>
+                        </metadataMap>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="bestResResourceData" productIdentifierKey="productCode" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="37,35"/>
+    </mapping>
+</metadataMap>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+            <capability xsi:type="magnificationCapability" magnification="1.0"/>
+            <capability xsi:type="colorMapCapability">
+                <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+                    <persisted/>
+                </colorMapParameters>
+            </capability>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="37"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="35"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+<capabilities>
+    <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="DEFAULT"/>
+    <capability xsi:type="rangeRingsOverlayCapability"/>
+    <capability xsi:type="colorableCapability" colorAsString="green1"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="colorMapCapability">
+        <colorMapParameters colorMapName="Radar/Storm Clear Reflectivity">
+            <persisted/>
+        </colorMapParameters>
+    </capability>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="bestResResourceData" productIdentifierKey="productCode" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+<metadataMap>
+    <mapping key="icao">
+        <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+    </mapping>
+    <mapping key="pluginName">
+        <constraint constraintType="EQUALS" constraintValue="radar"/>
+    </mapping>
+    <mapping key="productCode">
+        <constraint constraintType="IN" constraintValue="38,36"/>
+    </mapping>
+</metadataMap>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="38"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
+<resource>
+    <loadProperties loadWithoutData="false">
+        <resourceType>PLAN_VIEW</resourceType>
+        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
+        <capabilities>
+            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+            <capability xsi:type="rangeRingsOverlayCapability"/>
+        </capabilities>
+    </loadProperties>
+    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false">
+        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+    </properties>
+    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
+        <metadataMap>
+            <mapping key="icao">
+                <constraint constraintType="EQUALS" constraintValue="${icao}"/>
+            </mapping>
+            <mapping key="pluginName">
+                <constraint constraintType="EQUALS" constraintValue="radar"/>
+            </mapping>
+            <mapping key="productCode">
+                <constraint constraintType="EQUALS" constraintValue="36"/>
+            </mapping>
+        </metadataMap>
+    </resourceData>
+</resource>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
+            </descriptor>
+        </displays>
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="90"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="90"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
-        <displays xsi:type="d2DMapRenderableDisplay"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <displays xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="d2DMapRenderableDisplay" magnification="1.0" density="1.0" scale="CONUS" mapCenter="-96.86461947562519 40.47307545273292 0.0" zoomLevel="1.0">
             <descriptor xsi:type="mapDescriptor">
                 <resource>
                     <loadProperties loadWithoutData="true">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <perspectiveProperty xsi:type="d2dLoadProperties" loadMode="VALID_TIME_SEQ" timeMatchBasis="false"/>
                         <capabilities>
-                            <capability xsi:type="imagingCapability"
-                                interpolationState="false" brightness="1.0"
-                                contrast="1.0" alpha="1.0" />
-                            <capability xsi:type="rangeRingsOverlayCapability" />
+                            <capability xsi:type="imagingCapability" contrast="1.0" brightness="1.0" interpolationState="false" alpha="1.0"/>
+                            <capability xsi:type="rangeRingsOverlayCapability"/>
+                            <capability xsi:type="colorableCapability" colorAsString="green1"/>
+                            <capability xsi:type="magnificationCapability" magnification="1.0"/>
                         </capabilities>
                     </loadProperties>
-                    <properties isSystemResource="false"
-                        isBlinking="false" isMapLayer="false" isHoverOn="false"
-                        isVisible="true">
+                    <properties isVisible="true" isMapLayer="false" isBlinking="false" isSystemResource="false" renderingOrderId="IMAGE_LOCAL">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
                     </properties>
-                    <resourceData xsi:type="radarResourceData"
-                        isUpdatingOnMetadataOnly="false"
-                        isRequeryNecessaryOnTimeMatch="true">
+                    <resourceData xsi:type="radarResourceData" pointID="" mode="" latest="false" rangeRings="true" isRequeryNecessaryOnTimeMatch="true" isUpdatingOnMetadataOnly="false" retrieveData="true">
                         <metadataMap>
+                            <mapping key="icao">
+<constraint constraintType="EQUALS" constraintValue="${icao}"/>
+                            </mapping>
                             <mapping key="primaryElevationAngle">
-                                <constraint constraintValue="0.0"
-                                    constraintType="IN" />
+<constraint constraintType="IN" constraintValue="0.0"/>
                             </mapping>
                             <mapping key="productCode">
-                                <constraint constraintValue="66"
-                                    constraintType="EQUALS" />
-                            </mapping>
-                            <mapping key="icao">
-                                <constraint constraintValue="${icao}"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="66"/>
                             </mapping>
                             <mapping key="pluginName">
-                                <constraint constraintValue="radar"
-                                    constraintType="EQUALS" />
+<constraint constraintType="EQUALS" constraintValue="radar"/>
                             </mapping>
                         </metadataMap>
                     </resourceData>
                 </resource>
+                <resource>
+                    <loadProperties loadWithoutData="false">
+                        <resourceType>PLAN_VIEW</resourceType>
+                        <capabilities>
+                            <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+                            <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+                        </capabilities>
+                    </loadProperties>
+                    <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false" renderingOrderId="MAP_OUTLINE">
+                        <pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                    </properties>
+                    <resourceData xsi:type="mapResourceGroupData">
+                        <mapName>State/County Boundaries</mapName>
+                        <unloadList/>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>World</mapName>
+<unloadList/>
+<table>mapdata.world</table>
+<constraint>upper(name) NOT IN ('CANADA', 'MEXICO', 'UNITED STATES') AND first_coun != 'Y'</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="750000" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>State Boundaries</mapName>
+<unloadList/>
+<table>mapdata.states</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Canada</mapName>
+<unloadList/>
+<table>mapdata.canada</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>Mexico</mapName>
+<unloadList/>
+<table>mapdata.mexico</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="750000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>County Boundaries</mapName>
+<unloadList/>
+<table>mapdata.county</table>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                        <resource>
+                            <loadProperties loadWithoutData="false">
+<resourceType>PLAN_VIEW</resourceType>
+<capabilities>
+    <capability xsi:type="outlineCapability" outlineWidth="1" outlineOn="true" lineStyle="SOLID"/>
+    <capability xsi:type="colorableCapability" colorAsString="#9b9b9b"/>
+    <capability xsi:type="magnificationCapability" magnification="1.0"/>
+    <capability xsi:type="shadeableCapability" opacity="1.0"/>
+    <capability xsi:type="labelableCapability" xOffset="0" yOffset="0"/>
+</capabilities>
+                            </loadProperties>
+                            <properties isVisible="true" isMapLayer="true" isBlinking="false" isSystemResource="false">
+<pdProps minDisplayWidth="0" maxDisplayWidth="100000000"/>
+                            </properties>
+                            <resourceData xsi:type="dbMapResourceData">
+<mapName>two lakes</mapName>
+<unloadList/>
+<table>mapdata.lake</table>
+<constraint>name in ('Great Salt Lake', 'Lake Winnepeg')</constraint>
+<geomField>the_geom</geomField>
+                            </resourceData>
+                        </resource>
+                    </resourceData>
+                </resource>
+                <limitedNumberOfFrames>2147483647</limitedNumberOfFrames>
+                <gridGeometry rangeX="0 13391" rangeY="0 9999" envelopeMinX="-3217360.2108624117" envelopeMaxX="2889016.9103023135" envelopeMinY="-535763.0304681085" envelopeMaxY="4023747.8031403385">
+                    <CRS>PROJCS["Lambert_Conformal_Conic_1SP", 
+  GEOGCS["WGS84(DD)", 
+    DATUM["WGS84", 
+      SPHEROID["WGS84", 6378137.0, 298.257223563]], 
+    PRIMEM["Greenwich", 0.0], 
+    UNIT["degree", 0.017453292519943295], 
+    AXIS["Geodetic longitude", EAST], 
+    AXIS["Geodetic latitude", NORTH]], 
+  PROJECTION["Lambert_Conformal_Conic_1SP"], 
+  PARAMETER["semi_major", 6371200.0], 
+  PARAMETER["semi_minor", 6371200.0], 
+  PARAMETER["central_meridian", -95.0], 
+  PARAMETER["latitude_of_origin", 25.0], 
+  PARAMETER["scale_factor", 1.0], 
+  PARAMETER["false_easting", 0.0], 
+  PARAMETER["false_northing", 0.0], 
+  UNIT["m", 1.0], 
+  AXIS["Easting", EAST], 
+  AXIS["Northing", NORTH]]</CRS>
+                </gridGeometry>
+                <numberOfFrames>12</numberOfFrames>
+                <timeMatcher xsi:type="d2DTimeMatcher" forecastFilter="0" deltaFilter="0" loadMode="VALID_TIME_SEQ"/>
             </descriptor>
         </displays>
     </displayList>
+    <loopProperties>
+        <fwdFrameTime>231</fwdFrameTime>
+        <revFrameTime>1050</revFrameTime>
+        <firstFrameDwell>693</firstFrameDwell>
+        <lastFrameDwell>1485</lastFrameDwell>
+        <mode>Forward</mode>
+        <looping>false</looping>
+    </loopProperties>
 </bundle>

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/base4BitProducts.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/base4BitProducts.xml
@@ -319,7 +319,7 @@
             id="${icao}ZV" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -330,7 +330,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -341,7 +341,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -352,7 +352,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -363,7 +363,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -374,7 +374,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -385,7 +385,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -399,7 +399,7 @@
             id="${icao}ZSRM" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -410,7 +410,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -421,7 +421,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -432,7 +432,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -443,7 +443,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -454,7 +454,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -465,7 +465,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/baseTerminal4Panel.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/baseTerminal4Panel.xml
@@ -31,7 +31,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev1} ${elev2} ${elev6} ${elev8}"
-            id="${icao}${elev1}${elev2}${elev6}${elev8}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev1}${elev2}${elev6}${elev8}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -52,7 +52,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev1} ${elev3} ${elev5} ${elev6}"
-            id="${icao}${elev1}${elev3}${elev5}${elev6}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev1}${elev3}${elev5}${elev6}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -73,7 +73,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev1} ${elev2} ${elev3} ${elev4}"
-            id="${icao}${elev1}${elev2}${elev3}${elev4}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev1}${elev2}${elev3}${elev4}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -94,7 +94,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev3} ${elev7} ${elev8} ${elev9}"
-            id="${icao}${elev3}${elev7}${elev8}${elev9}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev3}${elev7}${elev8}${elev9}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -115,7 +115,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev8} ${elev9} ${elev10} ${elev12}"
-            id="${icao}${elev8}${elev9}${elev10}${elev12}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev8}${elev9}${elev10}${elev12}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -140,7 +140,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev1} ${elev2} ${elev6} ${elev8}"
-            id="${icao}${elev1}${elev2}${elev6}${elev8}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}${elev1}${elev2}${elev6}${elev8}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -161,7 +161,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev1} ${elev3} ${elev5} ${elev6}"
-            id="${icao}${elev1}${elev3}${elev5}${elev6}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}${elev1}${elev3}${elev5}${elev6}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -182,7 +182,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev1} ${elev2} ${elev3} ${elev4}"
-            id="${icao}${elev1}${elev2}${elev3}${elev4}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}${elev1}${elev2}${elev3}${elev4}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -203,7 +203,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev3} ${elev7} ${elev8} ${elev9}"
-            id="${icao}${elev3}${elev7}${elev8}${elev9}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}${elev3}${elev7}${elev8}${elev9}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -224,7 +224,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultTerminalRadar4PanelBlendedBestRes.xml"
             menuText="${elev8} ${elev9} ${elev10} ${elev12}"
-            id="${icao}${elev8}${elev9}${elev10}${elev12}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}${elev8}${elev9}${elev10}${elev12}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/baseRadarFourPanel.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/baseRadarFourPanel.xml
@@ -28,25 +28,25 @@
         titleText="------ 4-Panel Z+SRM/ZDR+V/KDP+HC/CC+SW ------" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.5 base data"
-        id="05dualpolbasedata">
+        fullBundleLoad="true" id="05dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.9 base data"
-        id="09dualpolbasedata">
+        fullBundleLoad="true" id="09dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.5 base data"
-        id="15dualpolbasedata">
+        fullBundleLoad="true" id="15dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="1.5--1.5" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="All Tilts base data"
-        id="AllTiltsdualpolbasedata">
+        fullBundleLoad="true" id="AllTiltsdualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--360.0" />
     </contribute>
@@ -54,79 +54,79 @@
         menuText="${icao} Hi base data tilts">
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.8 base data"
-            id="18dualpolbasedata">
+            fullBundleLoad="true" id="18dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="2.4 base data"
-            id="24dualpolbasedata">
+            fullBundleLoad="true" id="24dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="3.4 base data"
-            id="34dualpolbasedata">
+            fullBundleLoad="true" id="34dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="4.3 base data"
-            id="43dualpolbasedata">
+            fullBundleLoad="true" id="43dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="5.3 base data"
-            id="53dualpolbasedata">
+            fullBundleLoad="true" id="53dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="6.0 base data"
-            id="60dualpolbasedata">
+            fullBundleLoad="true" id="60dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="7.5 base data"
-            id="75dualpolbasedata">
+            fullBundleLoad="true" id="75dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="8.7 base data"
-            id="87dualpolbasedata">
+            fullBundleLoad="true" id="87dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="10.0 base data"
-            id="100dualpolbasedata">
+            fullBundleLoad="true" id="100dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="12.0 base data"
-            id="120dualpolbasedata">
+            fullBundleLoad="true" id="120dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="14.0 base data"
-            id="140dualpolbasedata">
+            fullBundleLoad="true" id="140dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="16.7 base data"
-            id="167dualpolbasedata">
+            fullBundleLoad="true" id="167dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="19.5 base data"
-            id="195dualpolbasedata">
+            fullBundleLoad="true" id="195dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>
@@ -135,22 +135,22 @@
     <contribute xsi:type="titleItem" id="${icao}4PanelZZDRHC+KDPCC"
         titleText="------ 4-Panel Z/ZDR/HC+KDP/CC ------" />
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.5 HC analysis" id="05dualpolHCanalysis">
+        menuText="0.5 HC analysis" fullBundleLoad="true" id="05dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.9 HC analysis" id="09dualpolHCanalysis">
+        menuText="0.9 HC analysis" fullBundleLoad="true" id="09dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="1.5 HC analysis" id="15dualpolHCanalysis">
+        menuText="1.5 HC analysis" fullBundleLoad="true" id="15dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="1.5--1.5" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="All Tilts HC analysis" id="AllTiltsdualpolHCanalysis">
+        menuText="All Tilts HC analysis" fullBundleLoad="true" id="AllTiltsdualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--360.0" />
     </contribute>
@@ -158,79 +158,79 @@
         menuText="${icao} Hi HC analysis tilts">
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="1.8 HC analysis"
-            id="18dualpolHCanalysis">
+            fullBundleLoad="true" id="18dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="2.4 HC analysis"
-            id="24dualpolHCanalysis">
+            fullBundleLoad="true" id="24dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="3.4 HC analysis"
-            id="34dualpolHCanalysis">
+            fullBundleLoad="true" id="34dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="4.3 HC analysis"
-            id="43dualpolHCanalysis">
+            fullBundleLoad="true" id="43dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="5.3 HC analysis"
-            id="53dualpolHCanalysis">
+            fullBundleLoad="true" id="53dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="6.0 HC analysis"
-            id="60dualpolHCanalysis">
+            fullBundleLoad="true" id="60dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="7.5 HC analysis"
-            id="75dualpolHCanalysis">
+            fullBundleLoad="true" id="75dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="8.7 HC analysis"
-            id="87dualpolHCanalysis">
+            fullBundleLoad="true" id="87dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="10.0 HC analysis"
-            id="100dualpolHCanalysis">
+            fullBundleLoad="true" id="100dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="12.0 HC analysis"
-            id="120dualpolHCanalysis">
+            fullBundleLoad="true" id="120dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="14.0 HC analysis"
-            id="140dualpolHCanalysis">
+            fullBundleLoad="true" id="140dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="16.7 HC analysis"
-            id="167dualpolHCanalysis">
+            fullBundleLoad="true" id="167dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolHCA.xml" menuText="19.5 HC analysis"
-            id="195dualpolHCanalysis">
+            fullBundleLoad="true" id="195dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/baseRadarFourPanelBestRes.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/baseRadarFourPanelBestRes.xml
@@ -28,7 +28,7 @@
         id="${icao}BestResZV" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 1.5 2.4 3.4"
-        id="${icao}05152434BestResZV">
+        fullBundleLoad="true" id="${icao}05152434BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -47,7 +47,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 0.9 1.5 1.8"
-        id="${icao}05091518BestResZV">
+        fullBundleLoad="true" id="${icao}05091518BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -66,7 +66,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.9 1.5 1.8 2.4 "
-        id="${icao}09151824BestResZV">
+        fullBundleLoad="true" id="${icao}09151824BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -85,7 +85,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="1.5 2.4 3.4 4.3"
-        id="${icao}15243443BestResZV">
+        fullBundleLoad="true" id="${icao}15243443BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -107,7 +107,7 @@
         id="${icao}BestResZSRM8"></contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 1.5 2.4 3.4"
-        id="${icao}05152434BestResZV">
+        fullBundleLoad="true" id="${icao}05152434BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -126,7 +126,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 0.9 1.5 1.8"
-        id="${icao}05091518BestResZV">
+        fullBundleLoad="true" id="${icao}05091518BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -145,7 +145,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.9 1.5 1.8 2.4 "
-        id="${icao}09151824BestResZV">
+        fullBundleLoad="true" id="${icao}09151824BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -164,7 +164,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="1.5 2.4 3.4 4.3"
-        id="${icao}15243443BestResZV">
+        fullBundleLoad="true" id="${icao}15243443BestResZV">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -186,7 +186,7 @@
         id="${icao}BestResZDR" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 1.5 2.4 3.4"
-        id="${icao}05152434BestResZZDR">
+        fullBundleLoad="true" id="${icao}05152434BestResZZDR">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -205,7 +205,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 0.9 1.5 1.8"
-        id="${icao}05091518BestResZZDR">
+        fullBundleLoad="true" id="${icao}05091518BestResZZDR">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -224,7 +224,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.9 1.5 1.8 2.4 "
-        id="${icao}09151824BestResZZDR">
+        fullBundleLoad="true" id="${icao}09151824BestResZZDR">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -243,7 +243,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="1.5 2.4 3.4 4.3"
-        id="${icao}15243443BestResZZDR">
+        fullBundleLoad="true" id="${icao}15243443BestResZZDR">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -265,7 +265,7 @@
         id="${icao}BestResCC" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 1.5 2.4 3.4"
-        id="${icao}05152434BestResZCC">
+        fullBundleLoad="true" id="${icao}05152434BestResZCC">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -284,7 +284,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 0.9 1.5 1.8"
-        id="${icao}05091518BestResZCC">
+        fullBundleLoad="true" id="${icao}05091518BestResZCC">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -303,7 +303,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.9 1.5 1.8 2.4 "
-        id="${icao}09151824BestResZCC">
+        fullBundleLoad="true" id="${icao}09151824BestResZCC">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -322,7 +322,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="1.5 2.4 3.4 4.3"
-        id="${icao}15243443BestResZCC">
+        fullBundleLoad="true" id="${icao}15243443BestResZCC">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -344,7 +344,7 @@
         id="${icao}BestResKDP" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 1.5 2.4 3.4"
-        id="${icao}05152434BestResZKDP">
+        fullBundleLoad="true" id="${icao}05152434BestResZKDP">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -363,7 +363,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.5 0.9 1.5 1.8"
-        id="${icao}05091518BestResZKDP">
+        fullBundleLoad="true" id="${icao}05091518BestResZKDP">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -382,7 +382,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="0.9 1.5 1.8 2.4 "
-        id="${icao}09151824BestResZKDP">
+        fullBundleLoad="true" id="${icao}09151824BestResZKDP">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -401,7 +401,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarFourPanelBlendedBestRes.xml" menuText="1.5 2.4 3.4 4.3"
-        id="${icao}15243443BestResZKDP">
+        fullBundleLoad="true" id="${icao}15243443BestResZKDP">
         <substitute key="icao" value="${icao}" />
         <substitute key="product1" value="153" />
         <substitute key="product2" value="94" />
@@ -423,7 +423,7 @@
         id="${icao}ZHCML" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolFourPanelZHCML.xml" menuText="0.5 1.5 2.4 3.4"
-        id="${icao}DualPolFourPanelZHCML">
+        fullBundleLoad="true" id="${icao}DualPolFourPanelZHCML">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation1" value="0.5" />
         <substitute key="elevation2" value="1.5" />
@@ -432,7 +432,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolFourPanelZHCML.xml" menuText="0.5 0.9 1.5 1.8"
-        id="${icao}DualPolFourPanelZHCML">
+        fullBundleLoad="true" id="${icao}DualPolFourPanelZHCML">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation1" value="0.5" />
         <substitute key="elevation2" value="0.9" />
@@ -441,7 +441,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolFourPanelZHCML.xml" menuText="0.9 1.5 1.8 2.4"
-        id="${icao}DualPolFourPanelZHCML">
+        fullBundleLoad="true" id="${icao}DualPolFourPanelZHCML">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation1" value="0.9" />
         <substitute key="elevation2" value="1.5" />
@@ -450,7 +450,7 @@
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolFourPanelZHCML.xml" menuText="1.5 2.4 3.4 4.3"
-        id="${icao}DualPolFourPanelZHCML">
+        fullBundleLoad="true" id="${icao}DualPolFourPanelZHCML">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation1" value="1.5" />
         <substitute key="elevation2" value="2.4" />
@@ -462,17 +462,17 @@
         id="${icao}OtherIn4Panel" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarComp05VILMax.xml" menuText="Comp 0.5 VIL Max"
-        id="${icao}Comp05VILMax">
+        fullBundleLoad="true" id="${icao}Comp05VILMax">
         <substitute key="icao" value="${icao}" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarTot1hr3hrComp.xml" menuText="Tot 1hr 3hr 0.5"
-        id="${icao}Tot1hr3hr05">
+        fullBundleLoad="true" id="${icao}Tot1hr3hr05">
         <substitute key="icao" value="${icao}" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarVILCompMax2Max3.xml" menuText="VIL Comp Max2 Max3"
-        id="${icao}VILCompMax2Max3">
+        fullBundleLoad="true" id="${icao}VILCompMax2Max3">
         <substitute key="icao" value="${icao}" />
     </contribute>
 </menuTemplate>

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/baseRadarLegacy.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/baseRadarLegacy.xml
@@ -718,7 +718,7 @@
             id="${icao}ZV" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -729,7 +729,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -740,7 +740,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -751,7 +751,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -762,7 +762,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -773,7 +773,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -784,7 +784,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -798,7 +798,7 @@
             id="${icao}ZSRM" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -809,7 +809,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -820,7 +820,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -831,7 +831,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -842,7 +842,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -853,7 +853,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -864,7 +864,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/terminal/baseRadarTerminalFourPanel.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/dualPol/terminal/baseRadarTerminalFourPanel.xml
@@ -31,7 +31,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlendedBestRes.xml"
             menuText="${elev0} ${elev1} ${elev2} ${elev3}"
-            id="${icao}${elev0}${elev1}${elev2}${elev3}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev0}${elev1}${elev2}${elev3}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -52,7 +52,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlendedBestRes.xml"
             menuText="${elev4} ${elev5} ${elev6} ${elev7}"
-            id="${icao}${elev0}${elev1}${elev2}${elev3}Terminal4panelZV"
+            fullBundleLoad="true" id="${icao}${elev0}${elev1}${elev2}${elev3}Terminal4panelZV"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -157,7 +157,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlendedBestRes.xml"
             menuText="${elev0} ${elev1} ${elev2} ${elev3}"
-            id="${icao}{elev0}${elev1}${elev2}${elev3}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}{elev0}${elev1}${elev2}${elev3}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />
@@ -178,7 +178,7 @@
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlendedBestRes.xml"
             menuText="${elev4} ${elev5} ${elev6} ${elev7}"
-            id="${icao}{elev0}${elev1}${elev2}${elev3}Terminal4panelZSRM8"
+            fullBundleLoad="true" id="${icao}{elev0}${elev1}${elev2}${elev3}Terminal4panelZSRM8"
             suppressErrors="${suppressErrors3}">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="180" />

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/with-0p2/baseRadarFourPanel.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/with-0p2/baseRadarFourPanel.xml
@@ -23,31 +23,31 @@
         titleText="------ 4-Panel Z+SRM/ZDR+V/KDP+HC/CC+SW ------" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="-0.4 base data"
-        id="-04dualpolbasedata">
+        fullBundleLoad="true" id="-04dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="-0.4---0.4" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.0 base data"
-        id="00dualpolbasedata">
+        fullBundleLoad="true" id="00dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--0.0" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.5 base data"
-        id="05dualpolbasedata">
+        fullBundleLoad="true" id="05dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.9 base data"
-        id="09dualpolbasedata">
+        fullBundleLoad="true" id="09dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="All Tilts base data"
-        id="AllTiltsdualpolbasedata">
+        fullBundleLoad="true" id="AllTiltsdualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="-0.4--360.0" />
     </contribute>
@@ -55,85 +55,85 @@
         menuText="${icao} Hi base data tilts">
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.5 base data"
-            id="15dualpolbasedata">
+            fullBundleLoad="true" id="15dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.5--1.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.8 base data"
-            id="18dualpolbasedata">
+            fullBundleLoad="true" id="18dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="2.4 base data"
-            id="24dualpolbasedata">
+            fullBundleLoad="true" id="24dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="3.4 base data"
-            id="34dualpolbasedata">
+            fullBundleLoad="true" id="34dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="4.3 base data"
-            id="43dualpolbasedata">
+            fullBundleLoad="true" id="43dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="5.3 base data"
-            id="53dualpolbasedata">
+            fullBundleLoad="true" id="53dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="6.0 base data"
-            id="60dualpolbasedata">
+            fullBundleLoad="true" id="60dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="7.5 base data"
-            id="75dualpolbasedata">
+            fullBundleLoad="true" id="75dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="8.7 base data"
-            id="87dualpolbasedata">
+            fullBundleLoad="true" id="87dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="10.0 base data"
-            id="100dualpolbasedata">
+            fullBundleLoad="true" id="100dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="12.0 base data"
-            id="120dualpolbasedata">
+            fullBundleLoad="true" id="120dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="14.0 base data"
-            id="140dualpolbasedata">
+            fullBundleLoad="true" id="140dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="16.7 base data"
-            id="167dualpolbasedata">
+            fullBundleLoad="true" id="167dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="19.5 base data"
-            id="195dualpolbasedata">
+            fullBundleLoad="true" id="195dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>
@@ -142,99 +142,99 @@
     <contribute xsi:type="titleItem" id="${icao}4PanelZZDRHC+KDPCC"
         titleText="------ 4-Panel Z/ZDR/HC+KDP/CC ------" />
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="-0.4 HC analysis" id="-04dualpolHCanalysis">
+        menuText="-0.4 HC analysis" fullBundleLoad="true" id="-04dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="-0.4---0.4" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.0 HC analysis" id="00dualpolHCanalysis">
+        menuText="0.0 HC analysis" fullBundleLoad="true" id="00dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--0.0" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.5 HC analysis" id="05dualpolHCanalysis">
+        menuText="0.5 HC analysis" fullBundleLoad="true" id="05dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.9 HC analysis" id="09dualpolHCanalysis">
+        menuText="0.9 HC analysis" fullBundleLoad="true" id="09dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="All Tilts HC analysis" id="AllTiltsdualpolHCanalysis">
+        menuText="All Tilts HC analysis" fullBundleLoad="true" id="AllTiltsdualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="-0.4--360.0" />
     </contribute>
     <contribute xsi:type="subMenu" id="${icao}HiHCnalysistiltsSubmenu"
         menuText="${icao} Hi HC analysis tilts">
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="1.5 HC analysis" id="15dualpolHCanalysis">
+            menuText="1.5 HC analysis" fullBundleLoad="true" id="15dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.5--1.5" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="1.8 HC analysis" id="18dualpolHCanalysis">
+            menuText="1.8 HC analysis" fullBundleLoad="true" id="18dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="2.4 HC analysis" id="24dualpolHCanalysis">
+            menuText="2.4 HC analysis" fullBundleLoad="true" id="24dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="3.4 HC analysis" id="34dualpolHCanalysis">
+            menuText="3.4 HC analysis" fullBundleLoad="true" id="34dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="4.3 HC analysis" id="43dualpolHCanalysis">
+            menuText="4.3 HC analysis" fullBundleLoad="true" id="43dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="5.3 HC analysis" id="53dualpolHCanalysis">
+            menuText="5.3 HC analysis" fullBundleLoad="true" id="53dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="6.0 HC analysis" id="60dualpolHCanalysis">
+            menuText="6.0 HC analysis" fullBundleLoad="true" id="60dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="7.5 HC analysis" id="75dualpolHCanalysis">
+            menuText="7.5 HC analysis" fullBundleLoad="true" id="75dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="8.7 HC analysis" id="87dualpolHCanalysis">
+            menuText="8.7 HC analysis" fullBundleLoad="true" id="87dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="10.0 HC analysis" id="100dualpolHCanalysis">
+            menuText="10.0 HC analysis" fullBundleLoad="true" id="100dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="12.0 HC analysis" id="120dualpolHCanalysis">
+            menuText="12.0 HC analysis" fullBundleLoad="true" id="120dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="14.0 HC analysis" id="140dualpolHCanalysis">
+            menuText="14.0 HC analysis" fullBundleLoad="true" id="140dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="16.7 HC analysis" id="167dualpolHCanalysis">
+            menuText="16.7 HC analysis" fullBundleLoad="true" id="167dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="19.5 HC analysis" id="195dualpolHCanalysis">
+            menuText="19.5 HC analysis" fullBundleLoad="true" id="195dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/with-0p2/baseRadarLegacy.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/with-0p2/baseRadarLegacy.xml
@@ -802,7 +802,7 @@
             id="${icao}ZV" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -813,7 +813,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -824,7 +824,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -835,7 +835,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -846,7 +846,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -857,7 +857,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -868,7 +868,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -882,7 +882,7 @@
             id="${icao}ZSRM" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -893,7 +893,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -904,7 +904,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -915,7 +915,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -926,7 +926,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -937,7 +937,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -948,7 +948,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/with0p2/baseRadarFourPanel.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/with0p2/baseRadarFourPanel.xml
@@ -23,25 +23,25 @@
         titleText="------ 4-Panel Z+SRM/ZDR+V/KDP+HC/CC+SW ------" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.0 base data"
-        id="00dualpolbasedata">
+        fullBundleLoad="true" id="00dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--0.0" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.5 base data"
-        id="05dualpolbasedata">
+        fullBundleLoad="true" id="05dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.9 base data"
-        id="09dualpolbasedata">
+        fullBundleLoad="true" id="09dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="All Tilts base data"
-        id="AllTiltsdualpolbasedata">
+        fullBundleLoad="true" id="AllTiltsdualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--360.0" />
     </contribute>
@@ -49,85 +49,85 @@
         menuText="${icao} Hi base data tilts">
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.5 base data"
-            id="15dualpolbasedata">
+            fullBundleLoad="true" id="15dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.5--1.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.8 base data"
-            id="18dualpolbasedata">
+            fullBundleLoad="true" id="18dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="2.4 base data"
-            id="24dualpolbasedata">
+            fullBundleLoad="true" id="24dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="3.4 base data"
-            id="34dualpolbasedata">
+            fullBundleLoad="true" id="34dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="4.3 base data"
-            id="43dualpolbasedata">
+            fullBundleLoad="true" id="43dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="5.3 base data"
-            id="53dualpolbasedata">
+            fullBundleLoad="true" id="53dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="6.0 base data"
-            id="60dualpolbasedata">
+            fullBundleLoad="true" id="60dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="7.5 base data"
-            id="75dualpolbasedata">
+            fullBundleLoad="true" id="75dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="8.7 base data"
-            id="87dualpolbasedata">
+            fullBundleLoad="true" id="87dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="10.0 base data"
-            id="100dualpolbasedata">
+            fullBundleLoad="true" id="100dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="12.0 base data"
-            id="120dualpolbasedata">
+            fullBundleLoad="true" id="120dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="14.0 base data"
-            id="140dualpolbasedata">
+            fullBundleLoad="true" id="140dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="16.7 base data"
-            id="167dualpolbasedata">
+            fullBundleLoad="true" id="167dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="19.5 base data"
-            id="195dualpolbasedata">
+            fullBundleLoad="true" id="195dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>
@@ -136,94 +136,94 @@
     <contribute xsi:type="titleItem" id="${icao}4PanelZZDRHC+KDPCC"
         titleText="------ 4-Panel Z/ZDR/HC+KDP/CC ------" />
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.0 HC analysis" id="00dualpolHCanalysis">
+        menuText="0.0 HC analysis" fullBundleLoad="true" id="00dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--0.0" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.5 HC analysis" id="05dualpolHCanalysis">
+        menuText="0.5 HC analysis" fullBundleLoad="true" id="05dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.9 HC analysis" id="09dualpolHCanalysis">
+        menuText="0.9 HC analysis" fullBundleLoad="true" id="09dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="All Tilts HC analysis" id="AllTiltsdualpolHCanalysis">
+        menuText="All Tilts HC analysis" fullBundleLoad="true" id="AllTiltsdualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--360.0" />
     </contribute>
     <contribute xsi:type="subMenu" id="${icao}HiHCnalysistiltsSubmenu"
         menuText="${icao} Hi HC analysis tilts">
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="1.5 HC analysis" id="15dualpolHCanalysis">
+            menuText="1.5 HC analysis" fullBundleLoad="true" id="15dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.5--1.5" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="1.8 HC analysis" id="18dualpolHCanalysis">
+            menuText="1.8 HC analysis" fullBundleLoad="true" id="18dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="2.4 HC analysis" id="24dualpolHCanalysis">
+            menuText="2.4 HC analysis" fullBundleLoad="true" id="24dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="3.4 HC analysis" id="34dualpolHCanalysis">
+            menuText="3.4 HC analysis" fullBundleLoad="true" id="34dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="4.3 HC analysis" id="43dualpolHCanalysis">
+            menuText="4.3 HC analysis" fullBundleLoad="true" id="43dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="5.3 HC analysis" id="53dualpolHCanalysis">
+            menuText="5.3 HC analysis" fullBundleLoad="true" id="53dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="6.0 HC analysis" id="60dualpolHCanalysis">
+            menuText="6.0 HC analysis" fullBundleLoad="true" id="60dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="7.5 HC analysis" id="75dualpolHCanalysis">
+            menuText="7.5 HC analysis" fullBundleLoad="true" id="75dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="8.7 HC analysis" id="87dualpolHCanalysis">
+            menuText="8.7 HC analysis" fullBundleLoad="true" id="87dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="10.0 HC analysis" id="100dualpolHCanalysis">
+            menuText="10.0 HC analysis" fullBundleLoad="true" id="100dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="12.0 HC analysis" id="120dualpolHCanalysis">
+            menuText="12.0 HC analysis" fullBundleLoad="true" id="120dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="14.0 HC analysis" id="140dualpolHCanalysis">
+            menuText="14.0 HC analysis" fullBundleLoad="true" id="140dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="16.7 HC analysis" id="167dualpolHCanalysis">
+            menuText="16.7 HC analysis" fullBundleLoad="true" id="167dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="19.5 HC analysis" id="195dualpolHCanalysis">
+            menuText="19.5 HC analysis" fullBundleLoad="true" id="195dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/with0p2/baseRadarLegacy.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/with0p2/baseRadarLegacy.xml
@@ -752,7 +752,7 @@
             id="${icao}ZV" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -763,7 +763,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -774,7 +774,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -785,7 +785,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -796,7 +796,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -807,7 +807,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -818,7 +818,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -832,7 +832,7 @@
             id="${icao}ZSRM" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -843,7 +843,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -854,7 +854,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -865,7 +865,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -876,7 +876,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -887,7 +887,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -898,7 +898,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/with0p3/baseRadarFourPanel.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/with0p3/baseRadarFourPanel.xml
@@ -23,25 +23,25 @@
         titleText="------ 4-Panel Z+SRM/ZDR+V/KDP+HC/CC+SW ------" />
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.3 base data"
-        id="03dualpolbasedata">
+        fullBundleLoad="true" id="03dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.3--0.3" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.5 base data"
-        id="05dualpolbasedata">
+        fullBundleLoad="true" id="05dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="0.9 base data"
-        id="09dualpolbasedata">
+        fullBundleLoad="true" id="09dualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem"
         file="bundles/DefaultRadarDualPolBaseData.xml" menuText="All Tilts base data"
-        id="AllTiltsdualpolbasedata">
+        fullBundleLoad="true" id="AllTiltsdualpolbasedata">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--360.0" />
     </contribute>
@@ -49,85 +49,85 @@
         menuText="${icao} Hi base data tilts">
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.5 base data"
-            id="15dualpolbasedata">
+            fullBundleLoad="true" id="15dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.5--1.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="1.8 base data"
-            id="18dualpolbasedata">
+            fullBundleLoad="true" id="18dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="2.4 base data"
-            id="24dualpolbasedata">
+            fullBundleLoad="true" id="24dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="3.4 base data"
-            id="34dualpolbasedata">
+            fullBundleLoad="true" id="34dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="4.3 base data"
-            id="43dualpolbasedata">
+            fullBundleLoad="true" id="43dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="5.3 base data"
-            id="53dualpolbasedata">
+            fullBundleLoad="true" id="53dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="6.0 base data"
-            id="60dualpolbasedata">
+            fullBundleLoad="true" id="60dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="7.5 base data"
-            id="75dualpolbasedata">
+            fullBundleLoad="true" id="75dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="8.7 base data"
-            id="87dualpolbasedata">
+            fullBundleLoad="true" id="87dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="10.0 base data"
-            id="100dualpolbasedata">
+            fullBundleLoad="true" id="100dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="12.0 base data"
-            id="120dualpolbasedata">
+            fullBundleLoad="true" id="120dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="14.0 base data"
-            id="140dualpolbasedata">
+            fullBundleLoad="true" id="140dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="16.7 base data"
-            id="167dualpolbasedata">
+            fullBundleLoad="true" id="167dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarDualPolBaseData.xml" menuText="19.5 base data"
-            id="195dualpolbasedata">
+            fullBundleLoad="true" id="195dualpolbasedata">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>
@@ -136,94 +136,94 @@
     <contribute xsi:type="titleItem" id="${icao}4PanelZZDRHC+KDPCC"
         titleText="------ 4-Panel Z/ZDR/HC+KDP/CC ------" />
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.3 HC analysis" id="03dualpolHCanalysis">
+        menuText="0.3 HC analysis" fullBundleLoad="true" id="03dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.3--0.3" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.5 HC analysis" id="05dualpolHCanalysis">
+        menuText="0.5 HC analysis" fullBundleLoad="true" id="05dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.5--0.5" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="0.9 HC analysis" id="09dualpolHCanalysis">
+        menuText="0.9 HC analysis" fullBundleLoad="true" id="09dualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.9--0.9" />
     </contribute>
     <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-        menuText="All Tilts HC analysis" id="AllTiltsdualpolHCanalysis">
+        menuText="All Tilts HC analysis" fullBundleLoad="true" id="AllTiltsdualpolHCanalysis">
         <substitute key="icao" value="${icao}" />
         <substitute key="elevation" value="0.0--360.0" />
     </contribute>
     <contribute xsi:type="subMenu" id="${icao}HiHCnalysistiltsSubmenu"
         menuText="${icao} Hi HC analysis tilts">
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="1.5 HC analysis" id="15dualpolHCanalysis">
+            menuText="1.5 HC analysis" fullBundleLoad="true" id="15dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.5--1.5" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="1.8 HC analysis" id="18dualpolHCanalysis">
+            menuText="1.8 HC analysis" fullBundleLoad="true" id="18dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="1.8--1.8" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="2.4 HC analysis" id="24dualpolHCanalysis">
+            menuText="2.4 HC analysis" fullBundleLoad="true" id="24dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="2.4--2.4" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="3.4 HC analysis" id="34dualpolHCanalysis">
+            menuText="3.4 HC analysis" fullBundleLoad="true" id="34dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="3.4--3.4" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="4.3 HC analysis" id="43dualpolHCanalysis">
+            menuText="4.3 HC analysis" fullBundleLoad="true" id="43dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="4.3--4.3" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="5.3 HC analysis" id="53dualpolHCanalysis">
+            menuText="5.3 HC analysis" fullBundleLoad="true" id="53dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="5.3--5.3" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="6.0 HC analysis" id="60dualpolHCanalysis">
+            menuText="6.0 HC analysis" fullBundleLoad="true" id="60dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="6.0--6.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="7.5 HC analysis" id="75dualpolHCanalysis">
+            menuText="7.5 HC analysis" fullBundleLoad="true" id="75dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="7.5--7.5" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="8.7 HC analysis" id="87dualpolHCanalysis">
+            menuText="8.7 HC analysis" fullBundleLoad="true" id="87dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="8.7--8.7" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="10.0 HC analysis" id="100dualpolHCanalysis">
+            menuText="10.0 HC analysis" fullBundleLoad="true" id="100dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="10.0--10.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="12.0 HC analysis" id="120dualpolHCanalysis">
+            menuText="12.0 HC analysis" fullBundleLoad="true" id="120dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="12.0--12.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="14.0 HC analysis" id="140dualpolHCanalysis">
+            menuText="14.0 HC analysis" fullBundleLoad="true" id="140dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="14.0--14.0" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="16.7 HC analysis" id="167dualpolHCanalysis">
+            menuText="16.7 HC analysis" fullBundleLoad="true" id="167dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="16.7--16.7" />
         </contribute>
         <contribute xsi:type="bundleItem" file="bundles/DefaultRadarDualPolHCA.xml"
-            menuText="19.5 HC analysis" id="195dualpolHCanalysis">
+            menuText="19.5 HC analysis" fullBundleLoad="true" id="195dualpolHCanalysis">
             <substitute key="icao" value="${icao}" />
             <substitute key="elevation" value="19.5--19.5" />
         </contribute>

--- a/cave/com.raytheon.viz.radar/localization/menus/radar/with0p3/baseRadarLegacy.xml
+++ b/cave/com.raytheon.viz.radar/localization/menus/radar/with0p3/baseRadarLegacy.xml
@@ -752,7 +752,7 @@
             id="${icao}ZV" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -763,7 +763,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -774,7 +774,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -785,7 +785,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -796,7 +796,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -807,7 +807,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -818,7 +818,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZV">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZV">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="27" />
@@ -832,7 +832,7 @@
             id="${icao}ZSRM" />
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 1.5 2.4 3.4"
-            id="${icao}4bit4panel05152434ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05152434ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -843,7 +843,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.5 0.9 1.5 1.8"
-            id="${icao}4bit4panel05091518ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel05091518ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -854,7 +854,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="0.9 1.5 1.8 2.4"
-            id="${icao}4bit4panel09151824ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel09151824ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -865,7 +865,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 2.4 3.4 4.3"
-            id="${icao}4bit4panel15243443ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel15243443ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -876,7 +876,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="1.5 4.3 6.0 10.0"
-            id="${icao}4bit4panel154360100ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel154360100ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -887,7 +887,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="4.3 5.3 6.0 7.5"
-            id="${icao}4bit4panel43536075ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel43536075ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />
@@ -898,7 +898,7 @@
         </contribute>
         <contribute xsi:type="bundleItem"
             file="bundles/DefaultRadarFourPanelBlended.xml" menuText="6.0 10.0 14.0 19.5"
-            id="${icao}4bit4panel60100140195ZSRM">
+            fullBundleLoad="true" id="${icao}4bit4panel60100140195ZSRM">
             <substitute key="icao" value="${icao}" />
             <substitute key="product1" value="19" />
             <substitute key="product2" value="56" />


### PR DESCRIPTION
- added `fullBundleLoad="true"` to menu files to force all resources to be drawn properly when opening in a new editor
- the only files that actually changed the menus were:
  - .../radar/dualPol/baseRadarLegacy.xml
  - .../radar/dualPol/baseRadarFourPanelBestRes.xml
  - .../radar/dualPol/baseRadarFourPanel.xml
- the rest were still changed anyway, in case we ever need those files, but likely the best course of action is to remove all unused files to make this less confusing