### PR TITLE
Fix Vorticity (AV) unit issue

### DIFF
--- a/edexOsgi/com.raytheon.uf.common.parameter/utility/common_static/base/parameter/definition/parameters.xml
+++ b/edexOsgi/com.raytheon.uf.common.parameter/utility/common_static/base/parameter/definition/parameters.xml
@@ -40,7 +40,7 @@
     <parameter>
         <name>Absolute Vorticity</name>
         <abbreviation>AV</abbreviation>
-        <unit>1/s</unit>
+        <unit>/s</unit>
     </parameter>
     <parameter>
         <name>Categorical Rain</name>
@@ -1152,12 +1152,12 @@
     <parameter>
         <name>Vertical u-component shear</name>
         <abbreviation>VUCSH</abbreviation>
-        <unit>1/s</unit>
+        <unit>/s</unit>
     </parameter>
     <parameter>
         <name>Vertical v-component shear</name>
         <abbreviation>VVCSH</abbreviation>
-        <unit>1/s</unit>
+        <unit>/s</unit>
     </parameter>
     <parameter>
         <name>Haines Index</name>
@@ -1217,7 +1217,7 @@
     <parameter>
         <name>Vertical Shear Speed</name>
         <abbreviation>VSS</abbreviation>
-        <unit>1/s</unit>
+        <unit>/s</unit>
     </parameter>
     <parameter>
         <name>Cloud Mixing Ratio</name>

--- a/edexOsgi/com.raytheon.uf.edex.plugin.grid/utility/common_static/base/styleRules/d2dContourStyleRules.xml
+++ b/edexOsgi/com.raytheon.uf.edex.plugin.grid/utility/common_static/base/styleRules/d2dContourStyleRules.xml
@@ -826,7 +826,7 @@ m/s| 1.0 | 0.0 | 4 |    |   |..|8000F0FF| | 0 | 5
             <parameter>geoVort</parameter>
         </paramLevelMatches>
         <contourStyle>
-            <displayUnits label="/1e5s">/100000</displayUnits>
+            <displayUnits label="/1e5s">/s*1.0E5</displayUnits>
             <contourLabeling labelSpacing="4" minMaxLabelFormat="#"
                 minLabel="N" maxLabel="X">
                 <increment>2</increment>
@@ -846,7 +846,7 @@ m/s| 1.0 | 0.0 | 4 |    |   |..|8000F0FF| | 0 | 5
             <parameter>RV</parameter>
         </paramLevelMatches>
         <contourStyle>
-            <displayUnits label="/1e5s">/100000</displayUnits>
+            <displayUnits label="/1e5s">/s*1.0E5</displayUnits>
             <smoothingDistance>100</smoothingDistance>
             <contourLabeling labelSpacing="4" minMaxLabelFormat="#"
                 minLabel="N" maxLabel="X">
@@ -2842,7 +2842,7 @@ C  | 1 | 0 | 4 |  |  |..|8000F0FF|,,,80 | 0 | 2
             <parameter>AV</parameter>
         </paramLevelMatches>
         <contourStyle>
-            <displayUnits label="/1e5s">/100000</displayUnits>
+            <displayUnits label="/1e5s">/s*1.0E5</displayUnits>
             <smoothingDistance>80</smoothingDistance>
             <contourLabeling labelSpacing="4" minMaxLabelFormat="#"
                 minLabel="N" maxLabel="X">
@@ -4238,7 +4238,7 @@ in | .03937 | 0 |  4 |    |   |..|8000F0FF| | 16 | \
             <parameter>geoVort</parameter>
         </paramLevelMatches>
         <contourStyle>
-            <displayUnits label="/1e5s">/100000</displayUnits>
+            <displayUnits label="/1e5s">/s*1.0E5</displayUnits>
             <smoothingDistance>100</smoothingDistance>
             <contourLabeling labelSpacing="4">
                 <increment>8</increment>

--- a/edexOsgi/com.raytheon.uf.edex.plugin.grid/utility/common_static/base/styleRules/gridImageryStyleRules.xml
+++ b/edexOsgi/com.raytheon.uf.edex.plugin.grid/utility/common_static/base/styleRules/gridImageryStyleRules.xml
@@ -1462,7 +1462,7 @@
             <parameter>geoVort</parameter>
         </paramLevelMatches>
         <imageStyle>
-            <displayUnits label="/1e5s">/100000</displayUnits>
+            <displayUnits label="/1e5s">/s*1.0E5</displayUnits>
             <range scale="LINEAR">
                 <minValue>-5</minValue>
                 <maxValue>30</maxValue>
@@ -5014,7 +5014,7 @@
             <parameter>geoVort</parameter>
         </paramLevelMatches>
         <imageStyle>
-            <displayUnits label="/1e5s">/100000</displayUnits>
+            <displayUnits label="/1e5s">/s*1.0E5</displayUnits>
             <range mirror="true" scale="LOG">
                 <minValue>5</minValue>
                 <maxValue>300</maxValue>


### PR DESCRIPTION
This is in reference to this DR: https://vlab.noaa.gov/awips-redmine/issues/2003073

If you already have a running EDEX and need to make this change, manually update the parameters.xml and then update the database table:

update parameter set unit='/s' where unit like '1/s';