### PR TITLE
Update update_NDM-v20.yml file to install SVN

### DIFF
--- a/.github/workflows/update_NDM-v20.yml
+++ b/.github/workflows/update_NDM-v20.yml
@@ -11,6 +11,11 @@ jobs:
     environment:
       name: VLAB
     steps:
+      # Install svn since it is no longer included by default in ubuntu-latest (ubuntu-24.04 image)
+      - name: Install svn package
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
       # Checkout this repo
       # this gets the latest code (and is run on the default branch)
       - name: Checkout awips2


### PR DESCRIPTION
The yml file runs on ubuntu-latest which in Dec 2024 was the ubuntu-24.04 image which had to remove a number of default packages because the image was getting to large, which included SVN (subversion), so now we need to install this package before we can use it.

https://github.com/actions/runner-images/issues/10636