### PR TITLE
Remove the ignite and startUp services RPM's

### DIFF
--- a/dist/comps.xml
+++ b/dist/comps.xml
@@ -154,7 +154,6 @@
          <packagereq type="mandatory">awips2-edex-menus-vb</packagereq>
 
          <packagereq type="mandatory">awips2-httpd-pypies</packagereq>
-         <packagereq type="mandatory">awips2-ignite</packagereq>
          <packagereq type="mandatory">awips2-java-security</packagereq>
          <packagereq type="mandatory">awips2-java</packagereq>
          <packagereq type="mandatory">awips2-thrift</packagereq>
@@ -223,7 +222,6 @@
          <packagereq type="mandatory">awips2-ldm</packagereq>
 
          <packagereq type="mandatory">awips2-edex</packagereq>
-         <packagereq type="mandatory">awips2-edex-enableservices</packagereq>
          <packagereq type="mandatory">awips2-edex-alertviz</packagereq>
          <packagereq type="mandatory">awips2-edex-archive</packagereq>
          <packagereq type="mandatory">awips2-edex-base</packagereq>
@@ -296,7 +294,6 @@
          <packagereq type="mandatory">awips2-yajsw</packagereq>
          <packagereq type="mandatory">awips2-edex-menus-vb</packagereq>
 
-         <packagereq type="mandatory">awips2-ignite</packagereq>
          <packagereq type="mandatory">awips2-java-security</packagereq>
          <packagereq type="mandatory">awips2-java</packagereq>
          <packagereq type="mandatory">awips2-thrift</packagereq>
@@ -504,7 +501,6 @@
          <packagereq type="default">awips2-common-foss</packagereq>
          <packagereq type="default">awips2-common-base</packagereq>
          <packagereq type="default">awips2-edex</packagereq>
-         <packagereq type="default">awips2-edex-enableservices</packagereq>
          <packagereq type="default">awips2-edex-alertviz</packagereq>
          <packagereq type="default">awips2-edex-archive</packagereq>
          <packagereq type="default">awips2-edex-base</packagereq>
@@ -1316,7 +1312,6 @@
          <packagereq type="default">awips2-common-foss</packagereq>
          <packagereq type="default">awips2-common-base</packagereq>
          <packagereq type="default">awips2-edex</packagereq>
-         <packagereq type="default">awips2-edex-enableservices</packagereq>
          <packagereq type="default">awips2-edex-alertviz</packagereq>
          <packagereq type="default">awips2-edex-base</packagereq>
          <packagereq type="default">awips2-edex-common-core</packagereq>
@@ -1613,7 +1608,6 @@
       <packagelist>
          <packagereq type="mandatory">awips2</packagereq>
          <packagereq type="mandatory">awips2-version</packagereq>
-         <packagereq type="mandatory">awips2-ignite</packagereq>
          <packagereq type="mandatory">awips2-java-security</packagereq>
          <packagereq type="mandatory">awips2-java</packagereq>
          <packagereq type="mandatory">awips2-python-ufpy</packagereq>


### PR DESCRIPTION
Since we are not using ignite, we don't need the RPM especially because on reboot, it would automatically start the ignite service

Additionally, we don't need the edex-enableservices RPM because it would enable ingest, ingestGrib, and request edex services for reboot, but on the ancillary (ingest only) machines we don't want those services started.