### PR TITLE
Updates to the LDM files - auto creating the merged pqacts

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -38,6 +38,11 @@ echo "**************************************************
 *                                                *
 *                                                *
 **************************************************">/awips2/repo/awips2/build/deploy.edex.awips2/esb/conf/banner.txt
+#Run LDM Merge Script
+cd /awips2/repo/awips2/rpms/awips2.upc/Installer.ldm/patch/etc
+perl merge_pqacts.pl main
+perl merge_pqacts.pl all
+cd /awips2/repo/awips2
 
 # If local source directories, exist, mount them to the container
 if [ $rpmname = "buildCAVE" ]; then

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/merge_pqacts.pl
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/merge_pqacts.pl
@@ -1,0 +1,99 @@
+#This perl script runs by taking in one argument (main or all) and creates a new pqact file by combining the individual pqacts
+
+if($#ARGV != 0)
+{
+  $args=$#ARGV+1; 
+  die "You provided " . $args . " argument(s) which is not valid. This script requires one command line argument.\nAn example of how to run this script is:\n\tperl merge_pqacts.pl all\n";
+}
+if($ARGV[0] ne "all" and $ARGV[0] ne "main")
+{
+  die "You provided an input argument of $ARGV[0] which is not valid. This script requires either \"all\" or \"main\" as an input argument. \nAn example of how to run this script is:\n\tperl merge_pqacts.pl all\n";
+}
+
+if($ARGV[0] eq "all")
+{ 
+  @files=("textplus","goesr","radar","mrms","grids");
+  $output="pqact.conf.priority";
+} elsif($ARGV[0] eq "main") {
+  @files=("textplus","mrms","grids");
+  $output="pqact.main";
+}
+
+@comments="";
+@pqentries="";
+
+foreach $file(@files)
+{
+  open IN, "<pqact.$file" or die "Cannot open pqact.$file\n";
+  @lines=<IN>;
+  $header=1;
+  $comment=1;
+  print "Reading in pqact.$file\n";
+
+  for($i=0; $i<=$#lines; $i++)
+  {
+    #print "$i out of $#lines\n";
+    chomp $lines[$i];
+    if($header==1 and $lines[$i]=~/^# [0-9]/)
+    {
+      #This is in the comments section
+      $fullComment=$lines[$i];
+      while ($lines[$i+1]!~/^# [0-9]/)
+      {
+        chomp $lines[$i+1];
+        if($lines[$i+1] eq "") { last; } 
+        $fullComment="$fullComment\n$lines[$i+1]";
+        $i++;
+      }
+      push(@comments,$fullComment);
+      next;
+
+    } elsif ($header==1 and ($lines[$i]=~/^\n/ or $lines[$i] eq "")) {
+      #This means we are done with the comments section
+      #print "We are done with the comments section\n";
+      $comment=0;
+    } elsif ($comment==0 and $header==1) {
+      #This is where we are finishing the specific header - read in the next 5 lines
+      #print "Finished with all headers\n";
+      for($j=0; $j<5; $j++)
+      {
+        chomp $lines[$i+$j];
+        #print "$lines[$i+$j]\n";
+        push(@pqentries,$lines[$i+$j]);
+      }
+      $i+=4;
+      $header=0;
+      next;
+    } elsif ($header==0) {
+      #This is the start of the pqact entries
+      #Need specific case to end for goesr
+      if($file eq "goesr" and $lines[$i]=~/GOES East Derived Products/)
+      {
+        $i=$#lines;
+        next;
+      }
+      #print "$lines[$i]\n";
+      push(@pqentries,$lines[$i]);
+    }
+
+  }
+  close IN;
+}
+
+open OUT, ">$output" or die "Cannot write $output\n";
+@sortedComments= sort @comments;
+
+
+print OUT "#
+# Unidata AWIPS LDM Default Pattern Actions
+#\n
+";
+foreach $sc(@sortedComments)
+{
+  print OUT $sc."\n";
+}
+
+foreach $entry(@pqentries)
+{
+  print OUT "$entry\n";
+}

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.conf.priority
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.conf.priority
@@ -1,42 +1,56 @@
 #
 # Unidata AWIPS LDM Default Pattern Actions
 #
-# USPLN1EX and LIGHTNING feeds are disabled in ldmd.conf by default
-# Regional grids are disabled (AK, HI, GU, PR, Pacific, etc.)
-#
+
+
 # 20160521	16.1.5	ESRL/GSD exp. HRRR added (HRRRX)
 # 20160801	16.2.2	"GFS" is now 0.25deg global (previously 0.5deg which is now named "GFS0p5")
 # 20170322      16.4.1  GOES-16(R) Experimental/Provisional Products on NOTHER
 # 20171010      17.1.1  Split files by feedtype, rm gridsi retired from NOAAport (DGEX-AK,GFS201,GFS80)
 # 20190109      18.1.1  GOES17 from  NIMAGE feed
 # 20210505      18.2.1  GFS is now 1.00deg global (previously 0.25deg)
-#                       MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
-#                       GOES16/17 CMI are coming from Unidata IDD
+# 20210505      18.2.1  GOES16/17 CMI are coming from Unidata IDD
 #                       GOES16 Derived products coming from NOAAPort
 #                       GOES16 GLM data coming from Unidata's IDD via Texas Tech
 #                       CIRA RGB GOES Satellite products added
+# 20210505      18.2.1  MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
 # 20230321      20.3.2  Update WW3 regex lines so we get the data
 # 20230620      20.3.2  LDM Version Update 6.13.14 -> 6.14.5 (this also updated the default pqact.conf --> pqact.conf.priority)
-# 20231004	20.3.2	Add RAWS data 
-#			Add additioanl NBM data
+# 20231004      20.3.2  Add RAWS data 
+#			Add additional NBM data
+# 20231109      20.3.2  Update SPCGuide gridded products to include Fire Weather and Dry Thunderstorm grids
 # 20231109      20.3.2  Updates to Unidata LDM based on NWS Change Log:
 #                       Add HREF/HiResW model
 #                       Update National Blended model entries, including adding standard deviations
 #                       Update RTOFS entry
-#                       Update SPCGuide gridded products to include Fire Weather and Dry Thunderstorm grids
-#                       Update level3 radar product entry
+# 20231109      20.3.2  Updates to Unidata LDM based on NWS Change Log:
+#                       Update level3 radar product entry to include SDUS4
 # 20231120      20.3.2  V24 TWORS Updates
+#                       Move viirs products from main to goes pqact
 #                       Update viirs polar product entry
 #                       Comment out TT GLM as it's now depricated and replaced by Unidata's
 # 20240105      20.3.2  Fix pqact error in Fire Weather and Dry Thunderstorm grids
-#                       Update viirs polar product entry
+# 20240105      20.3.2  Update viirs polar product entry
 # 20240226      20.3.2  Add Alaska regional NAM entry
+# 20240722      23.4.1  Update nucaps sounding entry
 # 20240722      23.4.1  V25 TOWRS Updates
 #                       Update viirs polar product entry (split up)
 #                       Update nucaps sounding entry
-#                       Add Wave Altimetery entry
+#			Add Wave Altimetery
 # 20240917      23.4.1  New entries for SSEC/CIMSS GOES Products (Lightning Cast and Turbulence)
 # 20241010      23.4.1  Add new entry for mPING data (NOAA/OU/CIWRO)
+# 20251119	23.4.1  Reformatted the MRMS pqact to match other ancillary pqacts
+# 20251119	23.4.1  Reformatted the textplus pqact to match other ancillary pqacts
+# 20251119      23.4.1  Reformatted the Grids pqact to match other ancillary pqacts
+# 20251119      23.4.1  Reformatted the Radar pqact to match other ancillary pqacts
+# 20251119      23.4.1  Update GOES Mesoscale sector to receive from SBN instead of Unidata (CONUS and FD are still the full stitched tile from Unidata)
+#			Reformatted the GOESR pqact to match other ancillary pqacts
+
+#########################
+#
+# Text+More Products
+#
+#########################
 
 # USPLN
 LIGHTNING	USPLN1EX
@@ -69,7 +83,7 @@ IDS|DDPLUS	^(SE[A-Z]{2}[0-9]{2}) ([A-Z]{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
 IDS|DDPLUS	^(WE[CHP][A-Z][0-9]{2}) ([A-Z]{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
-IDS|DDPLUS	^(A[AC-FH-RT-Z]..[0-9][0-9]) (.{4}) (..)(..)(..)
+ANY	^(A[A-FH-RT-Z]..[0-9][0-9]) (.{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/summaries/\1_\2_\3\4\5_(seq)
 ANY	^(AG..[0-9][0-9]) (KWB.) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/summaries/\1_\2_\3\4\5_(seq)
@@ -87,6 +101,9 @@ ANY	^(NWUS[01347-9].) (.{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/misc_adm_messages/\1_\2_\3\4\5_(seq)
 ANY	^(NWUS5.) (.{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/lsr/\1_\2_\3\4\5_(seq)
+ANY	^(WT..[0-9][0-9]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex /awips2/data_store/tropical/\1_\2_\3\4\5_(seq)
+
 # DR16660 - time string changed back to original for PBP and HFO
 IDS|DDPLUS	^(NW(HW|MY)50) (.{4}) (..)(..)(..)
 	FILE	-overwrite -log -close -edex	/awips2/data_store/lsr/\1_\2_\3\4\5_(seq)
@@ -124,6 +141,7 @@ EXP	^RAWS ...... (raws_ldad_)(........)(..)(..)(.xml)
 #
 EXP	^mPING XML (........)_(..)(..)(_mping.xml)
 	FILE	-overwrite -close -edex	/awips2/data_store/mping/\1/\2/\1_\2\3\4
+
 #
 # ACARS
 #
@@ -165,110 +183,21 @@ IDS|DDPLUS	^(WAAK4[789]) (PAWU) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/intlsigmet/\1_\2_\3\4\5_(seq)
 IDS|DDPLUS	^(W[CSV]PN[01][1-9]) (KKCI) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/intlsigmet/\1_\2_\3\4\5_(seq)
-#
-# ESRL Hourly Profiler Obs
+
 
 # INGEST NOAA/PSL WIND PROFILER BUFR DATA
 ANY	^(IUPT02) (....) (..)(..)(..)
-	FILE	-overwrite -log -close -edex	/data_store/profiler/(\3:yyyy)(\3:mm)\3/\4/\1_\2_\3\4\5_(seq).bufr.%Y%m%d%H
-
+	FILE	-overwrite -log -close -edex	/awips2/data_store/profiler/(\3:yyyy)(\3:mm)\3/\4/\1_\2_\3\4\5_(seq).bufr.%Y%m%d%H
 #
 # Redbook graphics
 #
 ANY	^([PQ][A-Z0-9]{3,5}) (....) (..)(..)(..) !redbook [^/]*/([^/]*)/([^/]*)/([^/]*)/([0-9]{8})
 	FILE	-overwrite -close -edex	/awips2/data_store/redbook/\4\5Z_\8_\7_\6-\1_\2.rb
-##########################
-#
-#  GOES Satellite Products
-#
-##########################
-# GOES 16/17 Single Channel (ABI) via NOAAPort/SBN - (not using)
-#NOTHER	^(TI[RSU]...) (KNES) (..)(..)(..) (...)
-#	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN/\1_\2_\3\4\5_\6_(seq)
-
-#/data/ldm/pub/native/satellite/GOES/GOES16/Products/CloudAndMoistureImagery/Mesoscale-2/Channel03/20210528/OR_ABI-L2-CMIPM2-M6C03_G16_s20211481451520_e20211481451520_c20211481451520.nc
-# GOES 16/17 Single Channel (ABI) via Unidata IDD -(using)
-NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudAndMoistureImagery/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
-	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CMI-IDD/\5\6\7\8.nc4
-
-# GOES 16/17 derived products + derived motion wind via SBN - (using)
-HDS	^(IXT.[8-9]9) (KNES) (..)(..)(..)
-	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
-NOTHER	^(IXT[WXY]01) (KNES) (..)(..)(..)
-	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
-NOTHER	^(TICY70) (KNWS) (..)(..)(..)
-	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
-
-# GOES 16/17 derived products via Unidata IDD - (not using)
-#NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/([^/]*)/([^/]*)/([0-9]{7})/([^/]*)(c[0-9]{7})(..)(.....).nc
-#	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/derived-IDD/\5\6\7\8.nc4
-
-# GOES 16/17 derived motion wind products via Unidata IDD - (not using - getting from SBN derived products)
-#NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/DerivedMotionWinds/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
-#	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/derived-IDD/\5\6\7\8.nc4
-
-# GOES 16 GLM gridded products via Texas Tech-->Unidata IDD (depricated)
-#NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/GeostationaryLightningMapper/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
-#	FILE	-close -edex	/awips2/data_store/GOES/\3/\6/GLM-IDD/\4\5\6\7.nc4
-
-# GOES GLM Raw data - don't use, AWIPS does not display the raw GLM data (not using)
-#DIFAX	^/data/cspp-geo/(EAST|WEST|GRB-R)/OR_GLM-L2-([^/]*).nc
-#	FILE	-close -edex	/awips2/data_store/GOES/GLM/\1_OR_GLM-L2-\2.nc
-
-#GOES GLM Tiles gridded products via ISatSS (not using)
-#EXP	(OR_GLM-L2-GLMF-M6_G(..)_T[0-9]{2}_e(........)(..).*)
-#	FILE	-close -edex	/awips2/data_store/GOES/\3/\4/GLMISatSS/\1
-
-#EXP	(OR_GLM-L3-GLMF-M6_G(..)_T[0-9]{2}_e(........)(..).*)
-#	FILE	-close -edex	/awips2/data_store/GOES/\3/\4/GLMISatSS/\1
-
-#GOES GLM Stitched gridded products via ISatSS (using)
-SPARE|NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/GLMISatSS/Level[23]/([^/]*)/([0-9]{8})/(OR_GLM-L[23]-GLMF-M6_G(..)_s(.......)(..).*)
-	FILE	-close -edex	/awips2/data_store/GOES/\3/\7/GLMISatSS-Stitched/\4
-
-# GOES CIRA derived products 
-NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/GeoColor/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
-	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CIRA/GeoColor/\5\6\7\8.nc4
-NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/DebraDust/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
-	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CIRA/DebraDust/\5\6\7\8.nc4
-NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudSnow/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
-	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CIRA/CloudSnow/\5\6\7\8.nc4
-
-# GOES CIMSS/SSEC Products
-#UWSSEC_AWIPS_LightningCast_GOES-18_RadM1_20240822-170028.nc.gz
-EXP	(UWSSEC_AWIPS_LightningCast_GOES.*)
-	FILE	-close	/awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/LightningCast/\1
-EXP	(UWSSEC_AWIPS_LightningCast_GOES.*)
-	EXEC	/awips2/ldm/dev/gunzip.py /awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/LightningCast/\1
-
-#UWSSEC_AWIPS_L2-GRIDTURBF-M6_G16_s20242351640205_e20242351649513_c20242351649557.nc
-EXP	(UWSSEC_AWIPS_L2-GRIDTURB.*)
-	FILE	-close -edex	/awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/Turbulence/\1
-#
-# NPP/VIIRS
-#
-# Polar products
-NOTHER	^(TI[CT]X..) (KNES)
-	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
-NOTHER	^(TIP[BCDHIPQ]10) (KNES) (......)
-	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
-NOTHER	^(TIP[AB]0[1|3|4|5]) (KNES) (......)
-	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
-NOTHER	^(TIP[AB]1[0|4|5|6]) (KNES) (......)
-	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
-#Wave Altimetry
-NOTHER	^(TIQB00) (KNES) (......)
-	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
 #
 # NEXRAD3 GEMPAK-generated national composite (1-4km)
 #
 FNEXRAD	^rad/NEXRCOMP/(...)/(...)_(........)_(....)	
 	FILE	-close -edex	/awips2/data_store/sat/nexrcomp_\3\4_\2.gini.png
-#
-# NEXRAD3 site products
-#
-NEXRAD3|HDS	^SDUS[2345678]. (....) (..)(..)(..).*/p(...)(...)
-	FILE	-overwrite -close -edex	/awips2/data_store/radar/(\2:yyyy)(\2:mm)\2//\3/\6/\6_\5_(\2:yyyy)(\2:mm)\2_\3\4	
 ##
 ## BUFR
 ##
@@ -285,7 +214,7 @@ HDS	^(JUTX0[1-9]) (....) (..)(..)(..)
 #
 # NUCAPS soundings
 #
-HDS	^(IUTN[01][1-9]) (....) (..)(..)(..)
+HDS	^(IUTN[01][1-5]) (....) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/nucaps/\1_\2_\3\4\5_(seq).bufr
 #
 # POES soundings
@@ -354,12 +283,121 @@ UNIWISC	^pnga2area Q. (.*) (.*) (NP_COMP) (.*)um (.*) (........) (....)
 UNIWISC	^pnga2area Q. (.*) (.*) (SP_COMP) (.*)um (.*) (........) (....)
 	FILE	-close -edex	/awips2/data_store/uniwisc/uniwisc_\1_\2\3\4_\5_\6_\7.area.png
 
+##########################
+#
+# GOES Satellite Products
+#
+##########################
+# GOES 16/17 Single Channel (ABI) via NOAAPort/SBN - (not using)
+#NOTHER	^(TI[RSU]...) (KNES) (..)(..)(..) (...)
+#	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN/\1_\2_\3\4\5_\6_(seq)
+
+#/data/ldm/pub/native/satellite/GOES/GOES16/Products/CloudAndMoistureImagery/Mesoscale-2/Channel03/20210528/OR_ABI-L2-CMIPM2-M6C03_G16_s20211481451520_e20211481451520_c20211481451520.nc
+# GOES 16/17 Single Channel (ABI) via Unidata IDD -(using)
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudAndMoistureImagery/(CONUS)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CMI-IDD/\5\6\7\8.nc4
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudAndMoistureImagery/(FullDisk)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CMI-IDD/\5\6\7\8.nc4
+# GOES Mesoscale ABI - via SBN
+#GOES East Meso
+ANY	^(TIS...) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN/\1_\2_\3\4\5_\6_(seq)
+#GOES West Meso
+ANY	^(TIU...) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN/\1_\2_\3\4\5_\6_(seq)
+ANY	^(TIR[APH]..) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN-OCONUS/\1_\2_\3\4\5_\6_(seq)
+ANY	^(TIUY..) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN-OCONUS/\1_\2_\3\4\5_\6_(seq)
+# GOES 16/17 derived products + derived motion wind via SBN - (using)
+HDS	^(IXT.[8-9]9) (KNES) (..)(..)(..)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
+NOTHER	^(IXT[WXY]01) (KNES) (..)(..)(..)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
+
+# Blended Hydro Suite - Advected Layer Preciptial Water (ALPW)
+NOTHER	^(TICY70) (KNES) (..)(..)(..)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
+
+# GOES 16/17 derived products via Unidata IDD - (not using)
+#NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/([^/]*)/([^/]*)/([0-9]{7})/([^/]*)(c[0-9]{7})(..)(.....).nc
+#	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/derived-IDD/\5\6\7\8.nc4
+
+# GOES 16/17 derived motion wind products via Unidata IDD - (not using - getting from SBN derived products)
+#NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/DerivedMotionWinds/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+#	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/derived-IDD/\5\6\7\8.nc4
+
+# GOES 16 GLM gridded products via Texas Tech-->Unidata IDD (depricated)
+#NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/GeostationaryLightningMapper/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+#	FILE	-close -edex	/awips2/data_store/GOES/\3/\6/GLM-IDD/\4\5\6\7.nc4
+
+# GOES GLM Raw data - don't use, AWIPS does not display the raw GLM data (not using)
+#DIFAX	^/data/cspp-geo/(EAST|WEST|GRB-R)/OR_GLM-L2-([^/]*).nc
+#	FILE	-close -edex	/awips2/data_store/GOES/GLM/\1_OR_GLM-L2-\2.nc
+
+#GOES GLM gridded products via ISatSS (not using)
+#EXP	(OR_GLM-L2-GLMF-M6_G(..)_T[0-9]{2}_e(........)(..).*)
+#	FILE	-close -edex	/awips2/data_store/GOES/\3/\4/GLMISatSS/\1
+
+#EXP	(OR_GLM-L3-GLMF-M6_G(..)_T[0-9]{2}_e(........)(..).*)
+#	FILE	-close -edex	/awips2/data_store/GOES/\3/\4/GLMISatSS/\1
+
+#GOES GLM Stitched gridded products via ISatSS (using)
+SPARE|NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/GLMISatSS/Level[23]/([^/]*)/([0-9]{8})/(OR_GLM-L[23]-GLMF-M6_G(..)_s(.......)(..).*)
+	FILE	-close -edex	/awips2/data_store/GOES/\3/\7/GLMISatSS-Stitched/\4
+# GOES CIRA derived products 
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/GeoColor/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CIRA/GeoColor/\5\6\7\8.nc4
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/DebraDust/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CIRA/DebraDust/\5\6\7\8.nc4
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudSnow/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CIRA/CloudSnow/\5\6\7\8.nc4
+
+# GOES CIMSS/SSEC Products
+#UWSSEC_AWIPS_LightningCast_GOES-18_RadM1_20240822-170028.nc.gz
+EXP	(UWSSEC_AWIPS_LightningCast_GOES.*)
+	FILE	-close	/awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/LightningCast/\1
+EXP	(UWSSEC_AWIPS_LightningCast_GOES.*)
+	EXEC	/awips2/ldm/dev/gunzip.py /awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/LightningCast/\1
+
+#UWSSEC_AWIPS_L2-GRIDTURBF-M6_G16_s20242351640205_e20242351649513_c20242351649557.nc
+EXP	(UWSSEC_AWIPS_L2-GRIDTURB.*)
+	FILE	-close -edex	/awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/Turbulence/\1
+
+#
+# NPP/VIIRS
+#
+# Polar products
+NOTHER	^(TI[CT]X..) (KNES) (......)
+	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
+NOTHER	^(TIP[BCDHIPQ]10) (KNES) (......)
+	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
+NOTHER	^(TIP[AB]0[1|3|4|5]) (KNES) (......)
+	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
+NOTHER	^(TIP[AB]1[0|4|5|6]) (KNES) (......)
+	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
+#Wave Altimetry
+NOTHER	^(TIQB00) (KNES) (......)
+	FILE	-close -edex	/awips2/data_store/viirs/\1_\2_\3
+
+
+#########################
+#
+# NEXRAD3 site products
+#
+#########################
+NEXRAD3|HDS	^SDUS[2345678]. (....) (..)(..)(..).*/p(...)(...)
+	FILE	-overwrite -close -edex	/awips2/data_store/radar/(\2:yyyy)(\2:mm)\2//\3/\6/\6_\5_(\2:yyyy)(\2:mm)\2_\3\4
+#########################
+#
+# MRMS Products
+#
+#########################
+
 # ===============================
 # = NCEP data available via IDD =
 # ===============================
 #
-# Multi-Radar Multi-Sensor (MRMS) - NOAAport
-#ALL MRMS Products (changed 6/18/2020 - tmeyer)
 # Multi-Radar Multi-Sensor (MRMS) - Unidata via NCO
 #/data/ldm/pub/native/radar/MRMS/Model/CONUS/MRMS_BrightBandTopHeight_00.00_20210430-184000.grib2
 #CONUS Domain
@@ -380,6 +418,29 @@ FNEXRAD	^/data/ldm/pub/native/radar/MRMS/.*/CARIB/MRMS(.*)([0-9]{8})-([0-9]{2})(
 #ProbSevere
 FNEXRAD	^/data/ldm/pub/native/radar/MRMS/.*/MRMS(.*)([0-9]{8})_([0-9]{2})([0-9]{4}).json
 	FILE	-edex -close	/awips2/data_store/grid/\2/\3/MRMS/ProbSevere/MRMS\1\2-\3\4.json
+
+# Multi-Radar Multi-Sensor (MRMS) - NOAAport
+#ALL MRMS Products (changed 6/18/2020 - tmeyer)
+#CONUS
+#NGRID	^YAU[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_\4_\5_\6_\7.grib2
+#Alaska Domain
+#NGRID	^YAA[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_AK_\4_\5_\6_\7.grib2
+#Hawaii Domain
+#NGRID	^YAH[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_HI_\4_\5_\6_\7.grib2
+#Caribbean Domain
+#NGRID	^YAC[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_CA_\4_\5_\6_\7.grib2
+#Guam Domain
+#NGRID	^YAG[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_GU_\4_\5_\6_\7.grib2
+#########################
+#
+# Gridded Model Products
+#
+#########################
 
 #
 # ------------------------------------------
@@ -490,7 +551,6 @@ NGRID	^[LM].Q... KWBR ...... !grib2/[^/]*/([^/]*)/#([^/]*)/([0-9]{8})([0-9]{2})(
 # --------------------------------------------------
 # - North American Mesoscale Forecast System (NAM) -
 # --------------------------------------------------
-#
 # NAM AK data
 NGRID	^[LM].S... KWBE ...... !grib2/ncep/NAM_84/#242/(............)(F...)/(.*)/.*
 	FILE	-edex -close
@@ -809,13 +869,13 @@ HDS	^LDIZ1[1-7] KWNS (..)(..)(..)
 # Day 4 
 HDS	^LDIZ48 KWNS (..)(..)(..)
 	FILE	-edex -log -close	/awips2/data_store/spc/(\1:yyyy)(\1:mm)(\1:dd)(\1:hh).day4_outlook.grib2
-
 # Prob of Severe Thunderstorm Grids
 ANY	^(LDIZ[1-9][1-9]) KWNS (..)(..)(..)
 	FILE	-edex -log -close	/awips2/data_store/spc/(\2:yyyy)(\2:mm)(\2:dd)(\2:hh)_\1_svr_outlook.grib2
 # Joint Fire Weather and Dry Thunderstorm Grids
 ANY	^(Y[YZ]U[D-I]3[3-8]) KWNS (..)(..)(..)
 	FILE	-edex -log -close	/awips2/data_store/spc/(\2:yyyy)(\2:mm)(\2:dd)(\2:hh)_\1_fw_outlook.grib2
+
 # UKMET
 #
 #HDS	^H..... EGRR ......[^!]*!grib/ukmet/([^/]*)/#([^/]*)/([0-9]{8})([0-9]{4})/(F[0-9]{3})/([^/]*)
@@ -1155,4 +1215,3 @@ NGRID	^(Y[B-Z][CDEM][RS][0-9][0-9]) (KWBH) (..)(..)(..)[^!]*!(grib|grib2)/[^/]*/
 #HiResW ARW/FV3 (HiResW v8)
 ANY	^([YZ].[CDEFM].{1,3}) (KWBS) (..)(..)(..)[^!]*!(grib|grib2)/[^/]*/([^/]*)/#([^/]*)/([0-9]{8})([0-9]{4})(F[0-9]{3})/([^/]*)
 	FILE	-overwrite -log -close -edex	/awips2/data_store/grid/(\3:yyyy)(\3:mm)\3/\4/HiResW/\(10)Z_\(11)_\(12)-\1_\2_\3\4\5_(seq).\6.%Y%m%d%H
-

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.goesr
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.goesr
@@ -1,14 +1,9 @@
 #
 # Unidata AWIPS LDM GOES/Satellite Specific Pattern Actions (this is to be used on an ancillary ingest only EDEX for gridded products - the pqact on the main EDEX should be edited to not have any duplicate actions from this file)
 #
-# 20160521	16.1.5	ESRL/GSD exp. HRRR added (HRRRX)
-# 20160801	16.2.2	"GFS" is now 0.25deg global (previously 0.5deg which is now named "GFS0p5")
 # 20170322      16.4.1  GOES-16(R) Experimental/Provisional Products on NOTHER
-# 20171010      17.1.1  Split files by feedtype, rm gridsi retired from NOAAport (DGEX-AK,GFS201,GFS80)
 # 20190109      18.1.1  GOES17 from  NIMAGE feed
-# 20210505      18.2.1  GFS is now 1.00deg global (previously 0.25deg)
-#                       MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
-#                       GOES16/17 CMI are coming from Unidata IDD
+# 20210505      18.2.1  GOES16/17 CMI are coming from Unidata IDD
 #                       GOES16 Derived products coming from NOAAPort
 #                       GOES16 GLM data coming from Unidata's IDD via Texas Tech
 #                       CIRA RGB GOES Satellite products added
@@ -20,11 +15,14 @@
 # 20240722      23.4.1  V25 TOWRS Updates
 #                       Update viirs polar product entry (split up)
 #                       Update nucaps sounding entry
+#			Add Wave Altimetery
 # 20240917      23.4.1  New entries for SSEC/CIMSS GOES Products (Lightning Cast and Turbulence)
+# 20251119      23.4.1  Update GOES Mesoscale sector to receive from SBN instead of Unidata (CONUS and FD are still the full stitched tile from Unidata)
+#			Reformatted the GOESR pqact to match other ancillary pqacts
 
 ##########################
 #
-#  GOES Satellite Products
+# GOES Satellite Products
 #
 ##########################
 # GOES 16/17 Single Channel (ABI) via NOAAPort/SBN - (not using)
@@ -33,14 +31,27 @@
 
 #/data/ldm/pub/native/satellite/GOES/GOES16/Products/CloudAndMoistureImagery/Mesoscale-2/Channel03/20210528/OR_ABI-L2-CMIPM2-M6C03_G16_s20211481451520_e20211481451520_c20211481451520.nc
 # GOES 16/17 Single Channel (ABI) via Unidata IDD -(using)
-NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudAndMoistureImagery/([^/]*)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudAndMoistureImagery/(CONUS)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
 	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CMI-IDD/\5\6\7\8.nc4
-
+NIMAGE	^/data/ldm/pub/native/satellite/GOES/([^/]*)/Products/CloudAndMoistureImagery/(FullDisk)/([^/]*)/([0-9]{8})/([^/]*)(c[0-9]{7})(..)(.....).nc
+	FILE	-close -edex	/awips2/data_store/GOES/\4/\7/CMI-IDD/\5\6\7\8.nc4
+# GOES Mesoscale ABI - via SBN
+#GOES East Meso
+ANY	^(TIS...) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN/\1_\2_\3\4\5_\6_(seq)
+#GOES West Meso
+ANY	^(TIU...) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN/\1_\2_\3\4\5_\6_(seq)
+ANY	^(TIR[APH]..) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN-OCONUS/\1_\2_\3\4\5_\6_(seq)
+ANY	^(TIUY..) (KNES) (..)(..)(..) (...)
+	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/CMI-SBN-OCONUS/\1_\2_\3\4\5_\6_(seq)
 # GOES 16/17 derived products + derived motion wind via SBN - (using)
 HDS	^(IXT.[8-9]9) (KNES) (..)(..)(..)
 	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
 NOTHER	^(IXT[WXY]01) (KNES) (..)(..)(..)
 	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
+
 # Blended Hydro Suite - Advected Layer Preciptial Water (ALPW)
 NOTHER	^(TICY70) (KNES) (..)(..)(..)
 	FILE	-close -edex	/awips2/data_store/GOES/(\3:yyyy)(\3:mm)\3/\4/derived-SBN/\1_KNES_\2\3\4\5-(seq)
@@ -89,6 +100,7 @@ EXP	(UWSSEC_AWIPS_LightningCast_GOES.*)
 #UWSSEC_AWIPS_L2-GRIDTURBF-M6_G16_s20242351640205_e20242351649513_c20242351649557.nc
 EXP	(UWSSEC_AWIPS_L2-GRIDTURB.*)
 	FILE	-close -edex	/awips2/data_store/GOES/%Y%m%d/%H/UWSSEC/Turbulence/\1
+
 #
 # NPP/VIIRS
 #

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.grids
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.grids
@@ -3,23 +3,21 @@
 #
 # 20160521	16.1.5	ESRL/GSD exp. HRRR added (HRRRX)
 # 20160801	16.2.2	"GFS" is now 0.25deg global (previously 0.5deg which is now named "GFS0p5")
-# 20170322      16.4.1  GOES-16(R) Experimental/Provisional Products on NOTHER
 # 20171010      17.1.1  Split files by feedtype, rm gridsi retired from NOAAport (DGEX-AK,GFS201,GFS80)
-# 20190109      18.1.1  GOES17 from  NIMAGE feed
 # 20210505      18.2.1  GFS is now 1.00deg global (previously 0.25deg)
-#                       MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
-#                       GOES16/17 CMI are coming from Unidata IDD
-#                       GOES16 Derived products coming from NOAAPort
-#                       GOES16 GLM data coming from Unidata's IDD via Texas Tech
-#                       CIRA RGB GOES Satellite products added
 # 20230321      20.3.2  Update WW3 regex lines so we get the data
-# 20231004      20.3.2  Add additioanl NBM data
 # 20231109      20.3.2  Updates to Unidata LDM based on NWS Change Log:
 #                       Add HREF/HiResW model
 #                       Update National Blended model entries, including adding standard deviations
 #                       Update RTOFS entry
-#                       Update SPCGuide gridded products to include Fire Weather and Dry Thunderstorm grids
 # 20240226      20.3.2  Add Alaska regional NAM entry
+# 20251119      23.4.1  Reformatted the Grids pqact to match other ancillary pqacts
+
+#########################
+#
+# Gridded Model Products
+#
+#########################
 
 #
 # ------------------------------------------
@@ -302,6 +300,20 @@ NGRID	Y.C.[0-9][0-9] KWBY ...... !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{2})(
 #
 FSL2	^GRIB2\.FSL\.HRRR\.(.......)_Lambert\.(.*)(Minute|Hour)\.(.*)\.(.*)\.([0-9]{8})([0-9]{2})([0-9]{2}).*
 	FILE	-close	/awips2/data_store/grid/\6/\7/HRRRX/staging/HRRRX_CONUS_3km_\6\7\8-concat-%Y%m%d_%H%M.grib2
+#
+#   -- GSD HRRR-Smoke --
+#
+# (Incoming Product ID: XGSL.GRIB.HRRR.Smoke.wrfsfc.FX.2114218000004)
+#
+# the grib2 process-id for the HRRR is originally 83; to make it easier to
+# diagnose problems let's change the process-id so it is instead 254. This
+# will make the model name of HRRR-Smoke unique in the AWIPS database.
+#
+FSL2	^(XGSL\.GRIB\.HRRR\.Smoke\.wrf...\.FX.*)
+	PIPE	-log -close	/awips2/ldm/decoders/changeHrrrSmokeProcessId.sh \1
+
+FSL2	^(ZZHH00\.XGSL\.GRIB\.HRRR\.Smoke\.wrf...\.FX.*)
+	FILE	-edex -close	/awips2/data_store/grid/HRRR-Smoke/\1.grib2
 #
 # ------------------------------------------------
 # - Short Range Ensemble Forecasts System (SREF) -

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.main
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.main
@@ -1,32 +1,35 @@
 #
-# Unidata AWIPS LDM Main Specific Pattern Actions (this file is used on Unidata's MAIN EDEX - radar and goes/satellite entries have been removed because these are ingested on ancillary EDEX's and we don't want to duplicate ingests)
+# Unidata AWIPS LDM Default Pattern Actions
 #
-# USPLN1EX and LIGHTNING feeds are disabled in ldmd.conf by default
-# Regional grids are disabled (AK, HI, GU, PR, Pacific, etc.)
-#
+
+
 # 20160521	16.1.5	ESRL/GSD exp. HRRR added (HRRRX)
 # 20160801	16.2.2	"GFS" is now 0.25deg global (previously 0.5deg which is now named "GFS0p5")
-# 20170322      16.4.1  GOES-16(R) Experimental/Provisional Products on NOTHER
 # 20171010      17.1.1  Split files by feedtype, rm gridsi retired from NOAAport (DGEX-AK,GFS201,GFS80)
-# 20190109      18.1.1  GOES17 from  NIMAGE feed
 # 20210505      18.2.1  GFS is now 1.00deg global (previously 0.25deg)
-#                       MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
-#                       GOES16/17 CMI are coming from Unidata IDD
-#                       GOES16 Derived products coming from NOAAPort
-#                       GOES16 GLM data coming from Unidata's IDD via Texas Tech
-#                       CIRA RGB GOES Satellite products added
+# 20210505      18.2.1  MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
 # 20230321      20.3.2  Update WW3 regex lines so we get the data
+# 20230620      20.3.2  LDM Version Update 6.13.14 -> 6.14.5 (this also updated the default pqact.conf --> pqact.conf.priority)
 # 20231004      20.3.2  Add RAWS data 
+#			Add additional NBM data
+# 20231109      20.3.2  Update SPCGuide gridded products to include Fire Weather and Dry Thunderstorm grids
 # 20231109      20.3.2  Updates to Unidata LDM based on NWS Change Log:
 #                       Add HREF/HiResW model
 #                       Update National Blended model entries, including adding standard deviations
 #                       Update RTOFS entry
-#                       Update SPCGuide gridded products to include Fire Weather and Dry Thunderstorm grids
-# 20231120      20.3.2  V24 TWORS Updates
-#                       Move viirs products from main to goes pqact
 # 20240105      20.3.2  Fix pqact error in Fire Weather and Dry Thunderstorm grids
 # 20240226      20.3.2  Add Alaska regional NAM entry
+# 20240722      23.4.1  Update nucaps sounding entry
 # 20241010      23.4.1  Add new entry for mPING data (NOAA/OU/CIWRO)
+# 20251119	23.4.1  Reformatted the MRMS pqact to match other ancillary pqacts
+# 20251119	23.4.1  Reformatted the textplus pqact to match other ancillary pqacts
+# 20251119      23.4.1  Reformatted the Grids pqact to match other ancillary pqacts
+
+#########################
+#
+# Text+More Products
+#
+#########################
 
 # USPLN
 LIGHTNING	USPLN1EX
@@ -59,7 +62,7 @@ IDS|DDPLUS	^(SE[A-Z]{2}[0-9]{2}) ([A-Z]{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
 IDS|DDPLUS	^(WE[CHP][A-Z][0-9]{2}) ([A-Z]{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
-IDS|DDPLUS	^(A[AC-FH-RT-Z]..[0-9][0-9]) (.{4}) (..)(..)(..)
+ANY	^(A[A-FH-RT-Z]..[0-9][0-9]) (.{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/summaries/\1_\2_\3\4\5_(seq)
 ANY	^(AG..[0-9][0-9]) (KWB.) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/summaries/\1_\2_\3\4\5_(seq)
@@ -77,6 +80,9 @@ ANY	^(NWUS[01347-9].) (.{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/misc_adm_messages/\1_\2_\3\4\5_(seq)
 ANY	^(NWUS5.) (.{4}) (..)(..)(..)
 	FILE	-overwrite -close -edex	/awips2/data_store/lsr/\1_\2_\3\4\5_(seq)
+ANY	^(WT..[0-9][0-9]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex /awips2/data_store/tropical/\1_\2_\3\4\5_(seq)
+
 # DR16660 - time string changed back to original for PBP and HFO
 IDS|DDPLUS	^(NW(HW|MY)50) (.{4}) (..)(..)(..)
 	FILE	-overwrite -log -close -edex	/awips2/data_store/lsr/\1_\2_\3\4\5_(seq)
@@ -256,12 +262,16 @@ UNIWISC	^pnga2area Q. (.*) (.*) (NP_COMP) (.*)um (.*) (........) (....)
 UNIWISC	^pnga2area Q. (.*) (.*) (SP_COMP) (.*)um (.*) (........) (....)
 	FILE	-close -edex	/awips2/data_store/uniwisc/uniwisc_\1_\2\3\4_\5_\6_\7.area.png
 
+#########################
+#
+# MRMS Products
+#
+#########################
+
 # ===============================
 # = NCEP data available via IDD =
 # ===============================
 #
-# Multi-Radar Multi-Sensor (MRMS) - NOAAport
-#ALL MRMS Products (changed 6/18/2020 - tmeyer)
 # Multi-Radar Multi-Sensor (MRMS) - Unidata via NCO
 #/data/ldm/pub/native/radar/MRMS/Model/CONUS/MRMS_BrightBandTopHeight_00.00_20210430-184000.grib2
 #CONUS Domain
@@ -282,6 +292,29 @@ FNEXRAD	^/data/ldm/pub/native/radar/MRMS/.*/CARIB/MRMS(.*)([0-9]{8})-([0-9]{2})(
 #ProbSevere
 FNEXRAD	^/data/ldm/pub/native/radar/MRMS/.*/MRMS(.*)([0-9]{8})_([0-9]{2})([0-9]{4}).json
 	FILE	-edex -close	/awips2/data_store/grid/\2/\3/MRMS/ProbSevere/MRMS\1\2-\3\4.json
+
+# Multi-Radar Multi-Sensor (MRMS) - NOAAport
+#ALL MRMS Products (changed 6/18/2020 - tmeyer)
+#CONUS
+#NGRID	^YAU[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_\4_\5_\6_\7.grib2
+#Alaska Domain
+#NGRID	^YAA[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_AK_\4_\5_\6_\7.grib2
+#Hawaii Domain
+#NGRID	^YAH[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_HI_\4_\5_\6_\7.grib2
+#Caribbean Domain
+#NGRID	^YAC[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_CA_\4_\5_\6_\7.grib2
+#Guam Domain
+#NGRID	^YAG[A-Z][0-9][0-9] KWNR (..)(..)(..) !grib2/[^/]*/[^/]*/#[^/]*/([0-9]{8})([0-9]{4})(F[0-9]..)/([^/]*)/.*
+#	FILE	-edex -close	/awips2/data_store/grid/(\1:yyyy)(\1:mm)\1/\2/MRMS/MRMS_GU_\4_\5_\6_\7.grib2
+#########################
+#
+# Gridded Model Products
+#
+#########################
 
 #
 # ------------------------------------------
@@ -705,19 +738,18 @@ FNMOC	^US058.*0110_0240_(.*)_(.*)_(.*)-(.*)
 #
 # Day 1
 HDS	^LDIZ1[1-7] KWNS (..)(..)(..)
-	FILE	-edex -log -close
-	/awips2/data_store/spc/(\1:yyyy)(\1:mm)(\1:dd)(\1:hh).day1_outlook.grib2
+	FILE	-edex -log -close	/awips2/data_store/spc/(\1:yyyy)(\1:mm)(\1:dd)(\1:hh).day1_outlook.grib2
 #
 # Day 4 
 HDS	^LDIZ48 KWNS (..)(..)(..)
-	FILE	-edex -log -close
-	/awips2/data_store/spc/(\1:yyyy)(\1:mm)(\1:dd)(\1:hh).day4_outlook.grib2
+	FILE	-edex -log -close	/awips2/data_store/spc/(\1:yyyy)(\1:mm)(\1:dd)(\1:hh).day4_outlook.grib2
 # Prob of Severe Thunderstorm Grids
 ANY	^(LDIZ[1-9][1-9]) KWNS (..)(..)(..)
 	FILE	-edex -log -close	/awips2/data_store/spc/(\2:yyyy)(\2:mm)(\2:dd)(\2:hh)_\1_svr_outlook.grib2
 # Joint Fire Weather and Dry Thunderstorm Grids
 ANY	^(Y[YZ]U[D-I]3[3-8]) KWNS (..)(..)(..)
 	FILE	-edex -log -close	/awips2/data_store/spc/(\2:yyyy)(\2:mm)(\2:dd)(\2:hh)_\1_fw_outlook.grib2
+
 # UKMET
 #
 #HDS	^H..... EGRR ......[^!]*!grib/ukmet/([^/]*)/#([^/]*)/([0-9]{8})([0-9]{4})/(F[0-9]{3})/([^/]*)

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.mrms
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.mrms
@@ -1,3 +1,15 @@
+#
+# Unidata AWIPS LDM MRMS Specific Pattern Actions (this is to be used on an ancillary ingest only EDEX for MRMS products - the pqact on the main EDEX should be edited to not have any duplicate actions from this file)
+#
+# 20210505      18.2.1  MRMS entries are now from Unidata's IDD NCO feed instead of NOAAPort
+# 20251119	23.4.1  Reformatted the MRMS pqact to match other ancillary pqacts
+
+#########################
+#
+# MRMS Products
+#
+#########################
+
 # ===============================
 # = NCEP data available via IDD =
 # ===============================

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.radar
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.radar
@@ -1,11 +1,14 @@
 #
-# Unidata AWIPS LDM Radar Specific Pattern Actions (this is to be used on an ancillary ingest only EDEX for gridded products - the pqact on the main EDEX should be edited to not have any duplicate actions from this file)
+# Unidata AWIPS LDM Radar Specific Pattern Actions (this is to be used on an ancillary ingest only EDEX for radar products - the pqact on the main EDEX should be edited to not have any duplicate actions from this file)
 #
 # 20231109      20.3.2  Updates to Unidata LDM based on NWS Change Log:
 #                       Update level3 radar product entry to include SDUS4
+# 20251119      23.4.1  Reformatted the Radar pqact to match other ancillary pqacts
 
+#########################
 #
 # NEXRAD3 site products
 #
+#########################
 NEXRAD3|HDS	^SDUS[2345678]. (....) (..)(..)(..).*/p(...)(...)
 	FILE	-overwrite -close -edex	/awips2/data_store/radar/(\2:yyyy)(\2:mm)\2//\3/\6/\6_\5_(\2:yyyy)(\2:mm)\2_\3\4

--- a/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.textplus
+++ b/rpms/awips2.upc/Installer.ldm/patch/etc/pqact.textplus
@@ -1,0 +1,251 @@
+#
+# Unidata AWIPS LDM Text+ Specific Pattern Actions. (this file is the base to build/add to, to create a full  pqact.conf.priority on the main EDEX machine if you are also running ancillary EDEX's so you don't have any duplicate actions)
+#
+# USPLN1EX and LIGHTNING feeds are disabled in ldmd.conf by default
+#
+# 20230620      20.3.2  LDM Version Update 6.13.14 -> 6.14.5 (this also updated the default pqact.conf --> pqact.conf.priority)
+# 20231004      20.3.2  Add RAWS data 
+#			Add additional NBM data
+# 20231109      20.3.2  Update SPCGuide gridded products to include Fire Weather and Dry Thunderstorm grids
+# 20240722      23.4.1  Update nucaps sounding entry
+# 20240105      20.3.2  Fix pqact error in Fire Weather and Dry Thunderstorm grids
+# 20241010      23.4.1  Add new entry for mPING data (NOAA/OU/CIWRO)
+# 20251119	23.4.1  Reformatted the textplus pqact to match other ancillary pqacts
+
+#########################
+#
+# Text+More Products
+#
+#########################
+
+# USPLN
+LIGHTNING	USPLN1EX
+	FILE	-close -edex	/awips2/data_store/lightning/%Y%m%d%H%M.uspln
+# NLDN
+LIGHTNING	LIGHTNING
+	FILE	-close -edex	/awips2/data_store/lightning/%Y%m%d%H%M.nldn
+# NLDN binlightning
+#HDS	^(SF(US|PA)41) ([A-Z]{4}) (..)(..)(..)
+#	FILE	-overwrite -edex -close	/awips2/data_store/nldn/\1_\3_\4\5\6_(seq).nldn
+# Earth Networks Total Lightning
+#NGRID	^(SFPA42) (KWBC) (..)(..)(..)
+#	FILE	-overwrite -edex -close	/awips2/data_store/entlightning/\1_\2_\3\4\5_(seq)
+
+##
+## All text products
+##
+#DDPLUS|IDS	^([A-Z][A-Z]{3}[0-9]{2}) ([KPTMC].{3}) (..)(..)(..)
+#	FILE	-overwrite -close -edex	/awips2/data_store/TEXT/\3_\4_\1_\2_\3\4\5_(seq)
+#	^FAUS(2[89]|30) KKCI.*
+IDS|DDPLUS	^FAUS(2[89]|30) (KKCI) (..)(..)(..) /p(CFQ..)
+	FILE	-overwrite -close -edex	/awips2/data_store/ccfp/\6_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(B.{5}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/stq_spot_fcst_reports/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(M[A-Z]{3}[0-9]{2}) ([KPTMC].{3}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(T[BCHPRTWXY][A-Z]{2}[0-9]{2}) ([A-Z]{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(SE[A-Z]{2}[0-9]{2}) ([A-Z]{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(WE[CHP][A-Z][0-9]{2}) ([A-Z]{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
+ANY	^(A[A-FH-RT-Z]..[0-9][0-9]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/summaries/\1_\2_\3\4\5_(seq)
+ANY	^(AG..[0-9][0-9]) (KWB.) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/summaries/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(C.{5}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/climate/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(F[A-FH-NP-Z]..[0-9][0-9]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/forecast/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(FOUS[1-589].) (....) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/forecast/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(FONT1[0-9]) KNHC (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_KNHC_\2\3\4_(seq)
+ANY	^(N[A-VYZ]....) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/misc_adm_messages/\1_\2_\3\4\5_(seq)
+ANY	^(NWUS[01347-9].) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/misc_adm_messages/\1_\2_\3\4\5_(seq)
+ANY	^(NWUS5.) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/lsr/\1_\2_\3\4\5_(seq)
+ANY	^(WT..[0-9][0-9]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex /awips2/data_store/tropical/\1_\2_\3\4\5_(seq)
+
+# DR16660 - time string changed back to original for PBP and HFO
+IDS|DDPLUS	^(NW(HW|MY)50) (.{4}) (..)(..)(..)
+	FILE	-overwrite -log -close -edex	/awips2/data_store/lsr/\1_\2_\3\4\5_(seq)
+ANY	^(NWUS2.) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/svrwx/\1_\2_\3\4\5_(seq)
+ANY	^(NXUS[0-57-9].) (....) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/misc_adm_messages/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(R.{5}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/xml/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(SM[UCM][SNX]..) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/synoptic/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(WP|IO|CP|EP|AL|SL) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/atcf/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(SHUS..) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/misc_sfc_obs/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(S[AP].{4}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/metar/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(S[MIN]V[DCE]..|SSV[DX]..) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/maritime/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(SXUS2[0123]) KWNB (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/maritime/\1_KWNB_\2\3\4_(seq)
+IDS|DDPLUS	^(SXUS..) (.{4}) (..)(..)(..) /pRER
+	FILE	-overwrite -close -edex	/awips2/data_store/text/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(UA(US|PA|NT)..) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/airep/\1_\3_\4\5\6_(seq)
+IDS|DDPLUS	^(UB.{4}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/pirep/\1_\2_\3\4\5_(seq)
+#
+# RAWS
+#
+EXP	^RAWS ...... (raws_ldad_)(........)(..)(..)(.xml)
+	FILE	-overwrite -close -edex	/awips2/data_store/ldadmesonet/\2/\3/\1\2\3\4\5
+#
+# mPING
+#
+EXP	^mPING XML (........)_(..)(..)(_mping.xml)
+	FILE	-overwrite -close -edex	/awips2/data_store/mping/\1/\2/\1_\2\3\4
+
+#
+# ACARS
+#
+#ANY	^(IUAX0[12]) (....) (..)(..)(..)
+#	FILE	-overwrite -log -close
+#	/awips2/data_store/acars_encrypted/(\3:yyyy)(\3:mm)\3/\4/\1_\2_\3\4\5_(seq).acars.%Y%m%d%H
+#ANY	^(IUAX0[12]) (....) (..)(..)(..)
+#	PIPE	-close /awips2/ldm/decoders/decrypt_file
+#	/awips2/data_store/acars_decrypted/(\3:yyyy)(\3:mm)\3/\4/\1_\2_\3\4\5_(seq).acars.%Y%m%d%H
+#EXP	^/awips2/data_store/acars_decrypted/(.*)
+#	FILE	-overwrite -log -close -edex
+#	/awips2/data_store/acars/acars_decrypted/\1
+# Need to make sure that IUAK and IUAX are disallowed.
+# IUAK are Alaskan profilers and IUAX has encrypted ACARS handled above!
+#ANY	^(IUA[^ACDEGHXK]0[12]) (....) (..)(..)(..)
+#	FILE	-overwrite -close -edex
+#	/awips2/data_store/acars_raw_decrypted/(\3:yyyy)(\3:mm)\3/\4/\1_\2_\3\4\5_(seq).bufr.%Y%m%d%H
+IDS|DDPLUS	^(U[SM].{4}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/raobs/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(U[^ABSM].{4}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/upperair/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(V.{5}) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/MAROB/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(W[BD-RTUW-Z]....) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/wwa/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(WSUS3[123]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/convsigmet/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(W[ACSV]US[04][1-6]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/nonconvsigmet/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(WAUS4[1-6]) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/airmet/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(JU[GHI]E..) (KKCI) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/gairmet/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(W[CSV]PA((0[1-9])|(1[0-3]))) (PHFO) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/intlsigmet/\1_\5_\6\7\8_(seq)
+IDS|DDPLUS	^(W[CSV]NT((0[1-9])|(1[0-3]))) (KKCI) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/intlsigmet/\1_\5_\6\7\8_(seq)
+IDS|DDPLUS	^(WAAK4[789]) (PAWU) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/intlsigmet/\1_\2_\3\4\5_(seq)
+IDS|DDPLUS	^(W[CSV]PN[01][1-9]) (KKCI) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/intlsigmet/\1_\2_\3\4\5_(seq)
+
+
+# INGEST NOAA/PSL WIND PROFILER BUFR DATA
+ANY	^(IUPT02) (....) (..)(..)(..)
+	FILE	-overwrite -log -close -edex	/awips2/data_store/profiler/(\3:yyyy)(\3:mm)\3/\4/\1_\2_\3\4\5_(seq).bufr.%Y%m%d%H
+#
+# Redbook graphics
+#
+ANY	^([PQ][A-Z0-9]{3,5}) (....) (..)(..)(..) !redbook [^/]*/([^/]*)/([^/]*)/([^/]*)/([0-9]{8})
+	FILE	-overwrite -close -edex	/awips2/data_store/redbook/\4\5Z_\8_\7_\6-\1_\2.rb
+#
+# NEXRAD3 GEMPAK-generated national composite (1-4km)
+#
+FNEXRAD	^rad/NEXRCOMP/(...)/(...)_(........)_(....)	
+	FILE	-close -edex	/awips2/data_store/sat/nexrcomp_\3\4_\2.gini.png
+##
+## BUFR
+##
+#
+# modelSoundings
+#
+HDS	^(JUS[ABX]4[1-9]) (KW(NO|BC)) (..)(..)(..)
+	FILE	-close	/awips2/data_store/modelsounding/staging/\1_\2_\4\5\6-concat-%Y%m%d_%H%M.bufr
+#
+# GOES soundings
+#
+HDS	^(JUTX0[1-9]) (....) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/goessounding/\1_\2_\3\4\5_(seq).bufr
+#
+# NUCAPS soundings
+#
+HDS	^(IUTN[01][1-5]) (....) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/nucaps/\1_\2_\3\4\5_(seq).bufr
+#
+# POES soundings
+#
+HDS	^(IUTX0[1-9]) (....) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/poessounding/\1_\2_\3\4\5_(seq).bufr
+#
+# BUFR MOS:
+#
+# GFS MOS-Based LAMP guidance			JSMF1[0-7]_KWNO	LAMP
+# Eta-based MOS BUFR messages			JSML1[0-7]_KWNO	ETA
+# GFS Short-range MOS BUFR messages		JSML3[0-8]_KWNO	GFS
+# Updated GFS Extended-range MOS BUFR messages	JSMT3[0-7]_KWNO	AVN
+# HPC						JSMT7[1-6]_KWNH	HPC
+# GFS Extended-range MOS BUFR for 18-84 hours	JSMT6[0-9]_KWNO MRF
+# GFS Extended-range MOS BUFR for 90-198 hours	JSMT7[0-9]_KWNO MRF
+#
+HDS	^(JSM([TL]..|F1[0-7])) (....) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrmos/\1_\3_\4\5\6_(seq).bufr
+# bufrUA
+HDS	^(IUS(Z[0-9]|Y4)[0-9]) ([A-Z]{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrua/\1_\3_\4\5\6_(seq).bufr
+#DCS18784
+HDS	^(IU[JS]N21) (KWBC) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrua/\1_\3_\4\5\6_(seq).bufr
+# bufrSIGWX
+HDS	^(JU[BCFJMNOTVW]E(00|9[679])) KKCI (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrsigwx/\1_KKCI_\3\4\5_(seq).bufr
+# bufrHDW High Density Winds
+HDS	^(J[ACEGHJKMNPQR]CX[1-9]1) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrhdw/\1_\2_\3\4\5_(seq).bufr
+# bufrSSMI Special Sensor Microwave Imagery
+HDS	^(ISXA..) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrssmi/\1_\2_\3\4\5_(seq).bufr
+# bufrASCAT Metop A
+HDS	^(JSXX(0[1-9]|10)) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrascat/\1_\3_\4\5\6_(seq).bufr
+# bufrASCAT Metop B
+HDS	^(JSYY(0[1-9]|10)) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrascat/\1_\3_\4\5\6_(seq).bufr
+# bufrMTHDW
+HDS	^(JUTX(([2-4]1)|53)) (.{4}) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/bufrmthdw/\1_\4_\5\6\7_(seq).bufr
+# JASON-3 Sea Surface Altimetry (wave height and anomaly)
+ANY	^(TIQB00) (KNES) (..)(..)(..)
+	FILE	-overwrite -close -edex	/awips2/data_store/polar/\1_\2_\3\4\5_(seq).%Y%m%d%H
+# NCEP Sea Surface Height Anomaly
+HDS	^ISZX[0-9][0-9] (EUMS) (..)(..)(..)
+	FILE	-close -edex	/awips2/data_store/ssha/\1_\2_\3\4\5_(seq).%Y%m%d%H
+#
+# UNIWISC McIDAS AREA FILES
+#
+# Rectilinear Global IR and WV Composites
+UNIWISC	^pnga2area Q. (G[IW]) (.*) (.*) (.*) (.*) (........) (....)
+	FILE	-close -edex	/awips2/data_store/uniwisc/uniwisc_\1_\2\3\4_\5_\6_\7.area.png
+
+# Mollweide Global IR and WV Composites
+UNIWISC	^pnga2area Q. (U[XY]) (.*) (.*)_IMG (.*)um (.*) (........) (....)
+	FILE	-close -edex	/awips2/data_store/uniwisc/uniwisc_\1_\2\3\4_\5_\6_\7.area.png
+
+# AMRC Arctic Composites
+UNIWISC	^pnga2area Q. (.*) (.*) (NP_COMP) (.*)um (.*) (........) (....)
+	FILE	-close -edex	/awips2/data_store/uniwisc/uniwisc_\1_\2\3\4_\5_\6_\7.area.png
+		
+# AMRC Antarctic Composites
+UNIWISC	^pnga2area Q. (.*) (.*) (SP_COMP) (.*)um (.*) (........) (....)
+	FILE	-close -edex	/awips2/data_store/uniwisc/uniwisc_\1_\2\3\4_\5_\6_\7.area.png
+


### PR DESCRIPTION
-Created separate pqacts for Text+ (everything else), GOESR, Radar, MRMS, and Grids (modeldata) 
-Only those pqacts should be editted
-When a build starts, a merge_pqacts.pl script runs and creates the full pqact.conf.priority and pqact.main files by combining the individual pqacts
-Additionally, the pqact.goesr file was updated to pull Mesoscale sectors from the SBN and only pull CONUS and FD from Unidata's re-tiled feed

This was done to alleviate differences and the need to make changes in multiple files where they could get out of sync