### PR TITLE
Fix issue with edex_camel@request restarting from memory issues

### DIFF
--- a/build/deploy.edex.awips2/esb/conf/wrapper.conf
+++ b/build/deploy.edex.awips2/esb/conf/wrapper.conf
@@ -95,7 +95,7 @@ wrapper.java.additional.6=-Djava.io.tmpdir=${AWIPS2_TEMP}
 # garbage collection settings
 wrapper.java.additional.gc.1=-XX:+UseConcMarkSweepGC
 wrapper.java.additional.gc.2=-XX:+HeapDumpOnOutOfMemoryError
-wrapper.java.additional.gc.3=-XX:HeapDumpPath=/data/fxa/cave/${SHORT_HOSTNAME}/
+wrapper.java.additional.gc.3=-XX:HeapDumpPath=/awips2/fxa/cave/${SHORT_HOSTNAME}/
 wrapper.java.additional.gc.4=-XX:SoftRefLRUPolicyMSPerMB=${SOFT_REF_LRU_POLICY_MS_PER_MB}
 
 wrapper.java.additional.stacktraces.1=-XX:-OmitStackTraceInFastThrow
@@ -135,7 +135,7 @@ wrapper.java.additional.log.5=-Djava.util.logging.config.file=${EDEX_HOME}/conf/
 
 # the max size in MB of any stream sent to thrift, this prevents the OutOfMemory
 # errors reported by thrift sometimes when the stream is corrupt/incorrect
-wrapper.java.additional.thrift.maxStreamSize=-Dthrift.stream.maxsize=320
+wrapper.java.additional.thrift.maxStreamSize=-Dthrift.stream.maxsize=600
 
 # define properties for rest path
 # required due to issue in camel 2.23+ reading env variables


### PR DESCRIPTION
We were getting a number of edex_camel@request restarts due to java out of memory errors. I increased the max stream size from 320 to 600and changed the output directory of the heap dump. The max memory was also increased in the request.sh file (awips2-core repo).

https://github.com/Unidata/awips-unidata-builds/issues/191