### PR TITLE
Fix/build rpms shell compatibility

### DIFF
--- a/build/build_rpms.sh
+++ b/build/build_rpms.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/bash -xe
 #
 # Build Unidata AWIPS RPMs from source
 # author: Michael James
@@ -39,7 +39,7 @@ pushd $REPO
 #
 # AWIPS Static files are too large to host on github
 #
-if [ ! -d awips2-static && ! $rpmname = "buildCAVE" ]; then
+if [ ! -d awips2-static ] && [ "$rpmname" != "buildCAVE" ]; then
    mkdir awips2-static
    cd awips2-static
    wget https://www.unidata.ucar.edu/downloads/awips2/static.tar

--- a/tests/build.xml
+++ b/tests/build.xml
@@ -97,7 +97,7 @@
 			<propertycopy name="forkCloneVm" from="@{testType}.FORK.CLONEVM" override="true" />
 
 			<junit printsummary="yes" forkmode="${forkMode}" clonevm="${forkCloneVm}" haltonfailure="no" failureproperty="tests.failed">
-				<jvmarg line="-Duser.dir=${testTypeSourceDir} -XX:PermSize=${env.INITIAL_PERMGEN_SIZE} -XX:MaxPermSize=${env.MAX_PERMGEN_SIZE}" />
+							<jvmarg line="-Duser.dir=${testTypeSourceDir} -XX:MetaspaceSize=${env.INITIAL_PERMGEN_SIZE} -XX:MaxMetaspaceSize=${env.MAX_PERMGEN_SIZE}" />
 				<classpath>
 					<!-- Any resources for tests -->
 					<pathelement location="${testTypeSourceDir}" />

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -10,7 +10,7 @@ then
    export MAX_PERMGEN_SIZE="192m"
 fi
 
-export ANT_OPTS="-XX:PermSize=${INITIAL_PERMGEN_SIZE} -XX:MaxPermSize=${MAX_PERMGEN_SIZE}  $*"
+export ANT_OPTS="-XX:MetaspaceSize=${INITIAL_PERMGEN_SIZE} -XX:MaxMetaspaceSize=${MAX_PERMGEN_SIZE}  $*"
 ant
 
 sudo rsync -rugl tmp/test-reports/html/* root@awipscm:/var/www/html/junit


### PR DESCRIPTION
Replaced obsolete PermGen JVM options with Java 8+ Metaspace options in the test configuration.

Changes:

Updated runTests.sh
Updated build.xml
Replaced -XX:PermSize with -XX:MetaspaceSize
Replaced -XX:MaxPermSize with -XX:MaxMetaspaceSize
Validation:

Shell syntax check passed.
XML syntax check passed.
Confirmed no obsolete PermGen options remain.